### PR TITLE
[ruby] Resolve Violations Reported by Rubocop

### DIFF
--- a/ruby/Steepfile
+++ b/ruby/Steepfile
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 D = Steep::Diagnostic
 
 target :app do
-  check "exec"
-  check "src"
-  check "test"
-  signature "sig"
+  check 'exec'
+  check 'src'
+  check 'test'
+  signature 'sig'
 
-  library "fileutils"
+  library 'fileutils'
 
   configure_code_diagnostics(D::Ruby.default)
 end


### PR DESCRIPTION
```bash
Inspecting 4 files
C...

Offenses:

Steepfile:1:1: C: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
D = Steep::Diagnostic
^
Steepfile:2:1: C: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
D = Steep::Diagnostic
^
Steepfile:4:9: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  check "main.rb"
        ^^^^^^^^^
Steepfile:5:9: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  check "src"
        ^^^^^
Steepfile:6:9: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  check "test"
        ^^^^^^
Steepfile:7:13: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  signature "sig"
            ^^^^^
Steepfile:9:11: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  library "fileutils"
          ^^^^^^^^^^^

4 files inspected, 7 offenses detected, 7 offenses corrected
```