### PR TITLE
[ruby] Optimise Github Actions Workflow

### DIFF
--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -1,0 +1,10 @@
+name: Setup Ruby Environment
+description: Setup Ruby with caching and dependency installation
+
+runs:
+  using: composite
+  steps:
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -8,3 +8,13 @@ runs:
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+    - name: Bundle Install with Caching
+      shell: bash
+      working-directory: ./ruby
+      run: |
+        mkdir -p vendor/bundle
+        bundle config set path vendor/bundle
+        bundle install
+        bundle lock --add-checksums

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -88,9 +88,7 @@ jobs:
       - uses: ./.github/actions/setup-ruby
       - name: RuboCop
         working-directory: ./ruby
-        run: |
-          gem install rubocop rubocop-minitest rubocop-performance
-          rubocop
+        run: rubocop
   steep:
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -102,6 +100,5 @@ jobs:
       - name: Steep
         working-directory: ./ruby
         run: |
-          gem install rbs-inline steep
           rbs-inline --output sig/generated/ .
           steep check

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -36,9 +36,42 @@ permissions:
   pull-requests: read
 
 jobs:
+  change-detection:
+    runs-on: ubuntu-latest
+    outputs:
+      ruby-changes: ${{ steps.ruby.outputs.changes }}
+      rubocop-changes: ${{ steps.rubocop.outputs.changes }}
+      steep-changes: ${{ steps.steep.outputs.changes }}
+    steps:
+      - name: Change Detection
+        uses: dorny/paths-filter@v4
+        id: change-detection
+        with:
+          filters: |
+            ruby: |
+              .github/actions/setup-ruby/action.yml
+              .github/workflows/ruby.yml
+              .ruby-version
+              ruby/**/*.rb
+            rubocop: |
+              .github/actions/setup-ruby/action.yml
+              .github/workflows/ruby.yml
+              .ruby-version
+              ruby/**/*.rb
+              ruby/rubocop.yml
+              ruby/rubocop_todo.yml
+            steep: |
+              .github/actions/setup-ruby/action.yml
+              .github/workflows/ruby.yml
+              .ruby-version
+              ruby/**/*.rb
+              ruby/**/*.rbs
+              ruby/Steepfile
   minitest:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    needs: change-detection
+    if: needs.change-detection.outputs.ruby-changes == 'true'
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-ruby
@@ -48,6 +81,8 @@ jobs:
   rubocop:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    needs: change-detection
+    if: needs.change-detection.outputs.rubocop-changes == 'true'
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-ruby
@@ -59,6 +94,8 @@ jobs:
   steep:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    needs: change-detection
+    if: needs.change-detection.outputs.steep-changes == 'true'
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-ruby

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,27 +33,38 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
-  test:
+  minitest:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-      # change this to (see https://github.com/ruby/setup-ruby#versioning):
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-      - name: Install Gems
-        run: gem install rubocop rubocop-minitest rubocop-performance rbs-inline steep
-      - name: Run Minitest
+      - uses: ./.github/actions/setup-ruby
+      - name: Minitest
         working-directory: ./ruby
-        run: rake
-      - name: Run RuboCop
-        working-directory: ./ruby
-        run: rubocop
-      - name: Run Steep
+        run: ruby test/application_test.rb
+  rubocop:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-ruby
+      - name: RuboCop
         working-directory: ./ruby
         run: |
+          gem install rubocop rubocop-minitest rubocop-performance
+          rubocop
+  steep:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-ruby
+      - name: Steep
+        working-directory: ./ruby
+        run: |
+          gem install rbs-inline steep
           rbs-inline --output sig/generated/ .
           steep check

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,16 +12,24 @@ on:
     branches:
       - master
     paths:
-      - '.github/workflows/ruby.yml'
-      - '.ruby-version'
-      - 'ruby/Rakefile'
-      - 'ruby/**/*.rb'
+      - .github/actions/setup-ruby/action.yml
+      - .github/workflows/ruby.yml
+      - .ruby-version
+      - ruby/**/*.rb
+      - ruby/**/*.rbs
+      - ruby/rubocop.yml
+      - ruby/rubocop_todo.yml
+      - ruby/Steepfile
   pull_request:
     paths:
-      - '.github/workflows/ruby.yml'
-      - '.ruby-version'
-      - 'ruby/Rakefile'
-      - 'ruby/**/*.rb'
+      - .github/actions/setup-ruby/action.yml
+      - .github/workflows/ruby.yml
+      - .ruby-version
+      - ruby/**/*.rb
+      - ruby/**/*.rbs
+      - ruby/rubocop.yml
+      - ruby/rubocop_todo.yml
+      - ruby/Steepfile
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Environment Variables
+.env
+
+# Ruby
+ruby/**/vendor/**
+
 # Python
 python/**/__pycache__/
-.env

--- a/ruby/.bundle/config
+++ b/ruby/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'rbs-inline', '~> 0.13.0', require: false
+gem 'rubocop', '~> 1.86.1', require: false
+gem 'rubocop-minitest', '~> 0.39.1', require: false
+gem 'rubocop-performance', '~> 1.26.1', require: false
+gem 'steep', '~> 2.0.0', require: false

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,0 +1,130 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.3)
+    concurrent-ruby (1.3.6)
+    csv (3.3.5)
+    ffi (1.17.4-x86_64-linux-gnu)
+    fileutils (1.8.0)
+    json (2.19.4)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    listen (3.10.0)
+      logger
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    parallel (2.0.1)
+    parser (3.3.11.1)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rbs (4.0.2)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rbs-inline (0.13.0)
+      prism (>= 0.29)
+      rbs (>= 3.8.0)
+    regexp_parser (2.12.0)
+    rubocop (1.86.1)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    rubocop-minitest (0.39.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
+    rubocop-performance (1.26.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
+    ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
+    steep (2.0.0)
+      concurrent-ruby (>= 1.1.10)
+      csv (>= 3.0.9)
+      fileutils (>= 1.1.0)
+      json (>= 2.1.0)
+      language_server-protocol (>= 3.17.0.4, < 4.0)
+      listen (~> 3.0)
+      logger (>= 1.3.0)
+      parser (>= 3.2)
+      prism (>= 0.25.0)
+      rainbow (>= 2.2.2, < 4.0)
+      rbs (~> 4.0)
+      securerandom (>= 0.1)
+      strscan (>= 1.0.0)
+      terminal-table (>= 2, < 5)
+      uri (>= 0.12.0)
+    strscan (3.1.8)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
+    tsort (0.2.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    uri (1.1.1)
+
+PLATFORMS
+  x86_64-linux-gnu
+
+DEPENDENCIES
+  rbs-inline (~> 0.13.0)
+  rubocop (~> 1.86.1)
+  rubocop-minitest (~> 0.39.1)
+  rubocop-performance (~> 1.26.1)
+  steep (~> 2.0.0)
+
+CHECKSUMS
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
+  ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
+  fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
+  json (2.19.4) sha256=670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac
+  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  parallel (2.0.1) sha256=337782d3e39f4121e67563bf91dd8ece67f48923d90698614773a0ec9a5b2c7d
+  parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
+  rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
+  rbs (4.0.2) sha256=af75671e66cd03434cc546622741ebf83f6197ec4328375805306330bf78ef25
+  rbs-inline (0.13.0) sha256=aba6e48c2d1b75276e8557376164f4b4ba96dd0204e779a5cee2af442bd30442
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rubocop (1.86.1) sha256=44415f3f01d01a21e01132248d2fd0867572475b566ca188a0a42133a08d4531
+  rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
+  rubocop-minitest (0.39.1) sha256=998398d6da4026d297f0f9bf709a1eac5f2b6947c24431f94af08138510cf7ed
+  rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  steep (2.0.0) sha256=6eb0ecc09637bbb54f0a5f2cf63daea6d3208ccace64b4f1107d976333605c30
+  strscan (3.1.8) sha256=aae2db611a225559f21ffbb71765c9a4e60fd262534a9ea84f4f11c7f32f679e
+  terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+
+BUNDLED WITH
+  4.0.10

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -2,11 +2,20 @@
 
 - Ruby 4.0.2
 
-## 2. Execution
+## 2. Install Gems via Gemfile and Bundler
+
+```command
+$ mkdir -p vendor/bundle
+$ bundle config set path vendor/bundle
+$ bundle install
+$ bundle lock --add-checksums
+```
+
+## 3. Execution
 
 Run the commands under `./ruby`
 
-### 2-1. Options
+### 3-1. Options
 
 | Order | Option        | Command-line Argument   |
 | :---- | :------------ | :---------------------- |
@@ -14,7 +23,7 @@ Run the commands under `./ruby`
 | 2     | language      | `English` or `Japanese` |
 | 3     | home_overflow | `true` or `false`       |
 
-### 2-2. Update Wiki List on Home and Sidebar
+### 3-2. Update Wiki List on Home and Sidebar
 
 ```command
 $ ruby exec/update_wiki_list_on_home_and_sidebar.rb
@@ -31,7 +40,7 @@ Check out an Up-to-date Wiki List on Sidebar at 'https://github.com/hayat01sh1da
 -------------------- Done Categorising the Entire github-wiki-organisers Wiki Pages 🎉 --------------------
 ```
 
-## 2-3. Export Unknown Wiki Count List by Namespace
+## 3-3. Export Unknown Wiki Count List by Namespace
 
 ```command
 $ ruby exec/export_unknown_wiki_count_list_by_namespace.rb Owner English
@@ -67,7 +76,7 @@ Check it out result on '../../unknown_wiki_count_list_by_namespace.txt' !!
 -------------------- Done Exporting Unknown Wiki Count List 🎉 --------------------
 ```
 
-### 2-3-2. Category
+### 3-3-2. Category
 
 ```command
 $ ruby exec/export_unknown_wiki_count_list_by_namespace.rb Category English
@@ -99,7 +108,7 @@ Check it out result on '../../unknown_wiki_count_list_by_namespace.txt' !!
 -------------------- Done Exporting Unknown Wiki Count List 🎉 --------------------
 ```
 
-## 2-4. Export Unknown Wiki List for LLM 
+## 3-4. Export Unknown Wiki List for LLM 
 
 ```command
 $ ruby exec/export_unknown_wiki_list_for_llm.rb
@@ -110,7 +119,7 @@ Check it out result on '../../export_unknown_wiki_list_for_llm.txt' !!
 -------------------- Done Exporting Unknown Wiki List 🎉 --------------------
 ```
 
-## 3. Bulk Execution of Unit Tests
+## 4. Bulk Execution of Unit Tests
 
 ```command
 $ rake


### PR DESCRIPTION
## 1. Problems to solve

1. Signature files and Steep file are missing in GHA workflow triggers.
2. GHA workflows are sequent at present, so the more jobs/steps. the more time to take.
3. The required gems are globally installed, but it should be managed by Gemfile/Gemfile.lock with the version fixed till any update comes.

## 2. Commit

- [Add missing trigger files to GHA workflows](https://github.com/hayat01sh1da/github-wiki-organisers/pull/38/commits/3406b9aaca5bbda2a93c51d4fafceeecbad26ffe)
- [Extract shared Ruby setup step to action configuration](https://github.com/hayat01sh1da/github-wiki-organisers/pull/38/commits/94b30c0daa78597bd803f0850d0a6c51c8aeeae8)
- [Trigger parallel jobs only if corresponding changes detected](https://github.com/hayat01sh1da/github-wiki-organisers/pull/38/commits/d80cd241c0cc2cf218d3dea9e4c363ef504f0894)
- [Migrate from global to local Gem installation](https://github.com/hayat01sh1da/github-wiki-organisers/pull/38/commits/9a8da218a375fb7faae75d72a40f09af75fdb2e2)