### PR TITLE
[ruby] Fix Github Actions Workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -43,6 +43,7 @@ jobs:
       rubocop-changes: ${{ steps.rubocop.outputs.changes }}
       steep-changes: ${{ steps.steep.outputs.changes }}
     steps:
+      - uses: actions/checkout@v6
       - name: Change Detection
         uses: dorny/paths-filter@v4
         id: change-detection


### PR DESCRIPTION
## Summary

Absence of `actions/checkout@v6` package import before `change-detection` step causes failure in CI.
Fixed it by adding the package on GHA configuration file.