### PR TITLE
[REVERT][ruby] Stop Managing Signature Files

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -117,5 +117,4 @@ jobs:
       - name: Steep
         working-directory: ./ruby
         run: |
-          bundle exec rbs-inline --output sig/generated/ .
           bundle exec steep check

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 # Environment Variables
 .env
 
-# Ruby
-ruby/sig/
-
 # Python
 python/**/__pycache__/

--- a/ruby/sig/generated/exec/export_unknown_wiki_count_list_by_namespace.rbs
+++ b/ruby/sig/generated/exec/export_unknown_wiki_count_list_by_namespace.rbs
@@ -1,0 +1,2 @@
+# Generated from exec/export_unknown_wiki_count_list_by_namespace.rb with RBS::Inline
+

--- a/ruby/sig/generated/exec/export_unknown_wiki_list_for_llm.rbs
+++ b/ruby/sig/generated/exec/export_unknown_wiki_list_for_llm.rbs
@@ -1,0 +1,2 @@
+# Generated from exec/export_unknown_wiki_list_for_llm.rb with RBS::Inline
+

--- a/ruby/sig/generated/exec/update_wiki_list_on_home_and_sidebar.rbs
+++ b/ruby/sig/generated/exec/update_wiki_list_on_home_and_sidebar.rbs
@@ -1,0 +1,2 @@
+# Generated from exec/update_wiki_list_on_home_and_sidebar.rb with RBS::Inline
+

--- a/ruby/sig/generated/src/application.rbs
+++ b/ruby/sig/generated/src/application.rbs
@@ -1,0 +1,66 @@
+# Generated from src/application.rb with RBS::Inline
+
+class Application
+  class NotImplementedError < StandardError
+  end
+
+  # @rbs base_path: String
+  # @rbs group_by: String
+  # @rbs language: String
+  # @rbs home_overflow: String
+  # @rbs return: void
+  def self.run: (?base_path: String, ?group_by: String, ?language: String, ?home_overflow: String) -> void
+
+  # @rbs base_path: String
+  # @rbs group_by: String
+  # @rbs language: String
+  # @rbs home_overflow: String
+  # @rbs return: void
+  def initialize: (base_path: String, group_by: String, language: String, home_overflow: String) -> void
+
+  # @rbs return: void
+  def validate!: () -> void
+
+  # @rbs return: void
+  def run: () -> void
+
+  private
+
+  attr_reader base_path: untyped
+
+  attr_reader group_by: untyped
+
+  attr_reader language: untyped
+
+  attr_reader home_overflow: untyped
+
+  attr_reader path_to_home: untyped
+
+  attr_reader path_to_sidebar: untyped
+
+  attr_reader path_to_github_wiki_organisers: untyped
+
+  attr_reader path_to_wikis_by_owner: untyped
+
+  attr_reader paths_to_wikis: untyped
+
+  # @rbs return: Array[String]
+  def target_paths: () -> Array[String]
+
+  # @rbs return: Regexp
+  def target_regexp: () -> Regexp
+
+  # @rbs return: String
+  def no_declaration: () -> String
+
+  # @rbs array: Array[untyped]
+  # @rbs hash: Hash[String, Array[untyped]]
+  # @rbs return: Hash[String, Array[String]]
+  def wiki_maps_with_namespace: (?Array[untyped] array, ?Hash[String, Array[untyped]] hash) -> Hash[String, Array[String]]
+
+  # @rbs return: Hash[String, Array[String]]
+  def owned_wiki_maps: () -> Hash[String, Array[String]]
+
+  # @rbs return: Hash[String, Array[String]]
+  def plain_wiki_maps: () -> Hash[String, Array[String]]
+end

--- a/ruby/sig/generated/src/home.rbs
+++ b/ruby/sig/generated/src/home.rbs
@@ -1,0 +1,34 @@
+# Generated from src/home.rb with RBS::Inline
+
+class Home < Application
+  HOME_URL: untyped
+
+  # @rbs base_path: String
+  # @rbs group_by: String
+  # @rbs language: String
+  # @rbs home_overflow: String
+  # @rbs return: void
+  def initialize: (?base_path: String, ?group_by: String, ?language: String, ?home_overflow: String) -> void
+
+  # @rbs return: String
+  def run: () -> String
+
+  private
+
+  attr_reader base_owner_url: untyped
+
+  attr_reader path_to_wikis_by_owner: untyped
+
+  # @rbs return: String
+  def path_to_home_template: () -> String
+
+  # @rbs return: Array[String]
+  def home_passage: () -> Array[String]
+
+  # @rbs return: void
+  def write_home_passage: () -> void
+
+  # @rbs array: Array[untyped]
+  # @rbs return: void
+  def write_concise_home_passage: (?Array[untyped] array) -> void
+end

--- a/ruby/sig/generated/src/sidebar.rbs
+++ b/ruby/sig/generated/src/sidebar.rbs
@@ -1,0 +1,23 @@
+# Generated from src/sidebar.rb with RBS::Inline
+
+class Sidebar < Application
+  # @rbs base_path: String
+  # @rbs group_by: String
+  # @rbs language: String
+  # @rbs home_overflow: String
+  # @rbs array: Array[untyped]
+  # @rbs return: void
+  def initialize: (?base_path: String, ?group_by: String, ?language: String, ?home_overflow: String, ?array: Array[untyped]) -> void
+
+  # @rbs return: void
+  def run: () -> void
+
+  private
+
+  attr_reader base_owner_url: untyped
+
+  attr_reader wiki_list: untyped
+
+  # @rbs return: void
+  def update_wiki_list: () -> void
+end

--- a/ruby/sig/generated/src/unknown_wiki_count_list_exporter.rbs
+++ b/ruby/sig/generated/src/unknown_wiki_count_list_exporter.rbs
@@ -1,0 +1,26 @@
+# Generated from src/unknown_wiki_count_list_exporter.rb with RBS::Inline
+
+class UnknownWikiCountListExporter < Application
+  # @rbs base_path: String
+  # @rbs group_by: String
+  # @rbs language: String
+  # @rbs home_overflow: String
+  # @rbs return: void
+  def initialize: (?base_path: String, ?group_by: String, ?language: String, ?home_overflow: String) -> void
+
+  # @rbs return: [Array[String], String]
+  def run: () -> [ Array[String], String ]
+
+  private
+
+  attr_reader path_to_export: untyped
+
+  # @rbs return: Array[String]
+  def namespace_list: () -> Array[String]
+
+  # @rbs return: Array[String]
+  def missing_count_list_by_namespace: () -> Array[String]
+
+  # @rbs return: Array[String]
+  def count_list_by_namespace: () -> Array[String]
+end

--- a/ruby/sig/generated/src/unknown_wiki_list_exporter_for_llm.rbs
+++ b/ruby/sig/generated/src/unknown_wiki_list_exporter_for_llm.rbs
@@ -1,0 +1,23 @@
+# Generated from src/unknown_wiki_list_exporter_for_llm.rb with RBS::Inline
+
+class UnknownWikiListExporterForLLM < Application
+  # @rbs base_path: String
+  # @rbs group_by: String
+  # @rbs language: String
+  # @rbs home_overflow: String
+  # @rbs return: void
+  def initialize: (?base_path: String, ?group_by: String, ?language: String, ?home_overflow: String) -> void
+
+  # @rbs return: String
+  def run: () -> String
+
+  private
+
+  attr_reader path_to_export: untyped
+
+  # @rbs return: String
+  def target_namespace: () -> String
+
+  # @rbs return: Array[String]
+  def unknown_wiki_list_for_llm: () -> Array[String]
+end

--- a/ruby/sig/generated/test/application_test.rbs
+++ b/ruby/sig/generated/test/application_test.rbs
@@ -1,0 +1,27 @@
+# Generated from test/application_test.rb with RBS::Inline
+
+class ApplicationTest < Minitest::Test
+  def setup: (?base_path: untyped, ?group_by: untyped, ?language: untyped, ?home_overflow: untyped) -> untyped
+
+  def teardown: () -> untyped
+
+  def test_validate_group_by!: () -> untyped
+
+  def test_validate_language!: () -> untyped
+
+  def test_validate_home_overflow!: () -> untyped
+
+  def test_self_run: () -> untyped
+
+  private
+
+  attr_reader base_path: untyped
+
+  attr_reader group_by: untyped
+
+  attr_reader language: untyped
+
+  attr_reader home_overflow: untyped
+
+  def test_file_maps: () -> untyped
+end

--- a/ruby/sig/generated/test/home_test.rbs
+++ b/ruby/sig/generated/test/home_test.rbs
@@ -1,0 +1,79 @@
+# Generated from test/home_test.rb with RBS::Inline
+
+class HomeTest < ApplicationTest
+  def setup: (?group_by: untyped, ?language: untyped, ?home_overflow: untyped) -> untyped
+
+  private
+
+  attr_reader path_to_home: untyped
+
+  attr_reader home: untyped
+
+  attr_reader path_to_wikis_by_owner: untyped
+
+  module English
+    class OwnedHomeTest < HomeTest
+      class NonOverflowTest < OwnedHomeTest
+        def test_self_run: () -> untyped
+
+        private
+
+        def home_passage: () -> untyped
+      end
+
+      class OverflowTest < OwnedHomeTest
+        def setup: () -> untyped
+
+        def test_self_run: () -> untyped
+
+        private
+
+        def home_passage: () -> untyped
+      end
+    end
+
+    class CategorisedHomeTest < HomeTest
+      def setup: () -> untyped
+
+      def test_self_run: () -> untyped
+
+      private
+
+      def home_passage: () -> untyped
+    end
+  end
+
+  module Japanese
+    class OwnedHomeTest < HomeTest
+      class NonOverflowTest < OwnedHomeTest
+        def setup: () -> untyped
+
+        def test_self_run: () -> untyped
+
+        private
+
+        def home_passage: () -> untyped
+      end
+
+      class OverflowTest < OwnedHomeTest
+        def setup: () -> untyped
+
+        def test_self_run: () -> untyped
+
+        private
+
+        def home_passage: () -> untyped
+      end
+    end
+
+    class CategorisedHomeTest < HomeTest
+      def setup: () -> untyped
+
+      def test_self_run: () -> untyped
+
+      private
+
+      def home_passage: () -> untyped
+    end
+  end
+end

--- a/ruby/sig/generated/test/sidebar_test.rbs
+++ b/ruby/sig/generated/test/sidebar_test.rbs
@@ -1,0 +1,53 @@
+# Generated from test/sidebar_test.rb with RBS::Inline
+
+class SidebarTest < ApplicationTest
+  def setup: (?group_by: untyped, ?language: untyped) -> untyped
+
+  private
+
+  attr_reader path_to_sidebar: untyped
+
+  attr_reader sidebar: untyped
+
+  module English
+    class OwnedSidebarTest < SidebarTest
+      def test_self_run: () -> untyped
+
+      private
+
+      def wiki_list: () -> untyped
+    end
+
+    class PlainSidebarTest < SidebarTest
+      def setup: () -> untyped
+
+      def test_self_run: () -> untyped
+
+      private
+
+      def wiki_list: () -> untyped
+    end
+  end
+
+  module Japanese
+    class OwnedSidebarTest < SidebarTest
+      def setup: () -> untyped
+
+      def test_self_run: () -> untyped
+
+      private
+
+      def wiki_list: () -> untyped
+    end
+
+    class PlainSidebarTest < SidebarTest
+      def setup: () -> untyped
+
+      def test_self_run: () -> untyped
+
+      private
+
+      def wiki_list: () -> untyped
+    end
+  end
+end

--- a/ruby/sig/generated/test/unknown_wiki_count_list_exporter_test.rbs
+++ b/ruby/sig/generated/test/unknown_wiki_count_list_exporter_test.rbs
@@ -1,0 +1,161 @@
+# Generated from test/unknown_wiki_count_list_exporter_test.rb with RBS::Inline
+
+class UnknownWikiCountListExporterTest < ApplicationTest
+  def setup: (?group_by: untyped, ?language: untyped) -> untyped
+
+  private
+
+  attr_reader path_to_unknown_wiki_count_list: untyped
+
+  attr_reader unknown_wiki_count_list: untyped
+
+  module English
+    class OwnershipTest < UnknownWikiCountListExporterTest
+      class RegularCase1 < OwnershipTest
+        def test_self_run: () -> untyped
+
+        private
+
+        def unknown_wiki_count_list_by_namespace: () -> untyped
+      end
+
+      class RegularCase2 < OwnershipTest
+        def test_self_run: () -> untyped
+
+        private
+
+        def unknown_wiki_count_list_by_namespace: () -> untyped
+
+        def test_file_maps: () -> untyped
+      end
+
+      class IrregularCase1 < OwnershipTest
+        def test_self_run: () -> untyped
+
+        private
+
+        def unknown_wiki_count_list_by_namespace: () -> untyped
+
+        def test_file_maps: () -> untyped
+      end
+
+      class IrregularCase2 < OwnershipTest
+        def test_self_run: () -> untyped
+
+        private
+
+        def unknown_wiki_count_list_by_namespace: () -> untyped
+
+        def test_file_maps: () -> untyped
+      end
+
+      class IrregularCase3 < OwnershipTest
+        def test_self_run: () -> untyped
+
+        private
+
+        def unknown_wiki_count_list_by_namespace: () -> untyped
+
+        def test_file_maps: () -> untyped
+      end
+    end
+
+    class CategoryTest < UnknownWikiCountListExporterTest
+      def setup: () -> untyped
+
+      class RegularCase < CategoryTest
+        def test_self_run: () -> untyped
+
+        private
+
+        def unknown_wiki_count_list_by_namespace: () -> untyped
+      end
+
+      class IrregularCase < CategoryTest
+        def test_self_run: () -> untyped
+
+        private
+
+        def unknown_wiki_count_list_by_namespace: () -> untyped
+
+        def test_file_maps: () -> untyped
+      end
+    end
+  end
+
+  module Japanese
+    class OwnershipTest < UnknownWikiCountListExporterTest
+      def setup: () -> untyped
+
+      class RegularCase1 < OwnershipTest
+        def test_self_run: () -> untyped
+
+        private
+
+        def unknown_wiki_count_list_by_namespace: () -> untyped
+      end
+
+      class RegularCase2 < OwnershipTest
+        def test_self_run: () -> untyped
+
+        private
+
+        def unknown_wiki_count_list_by_namespace: () -> untyped
+
+        def test_file_maps: () -> untyped
+      end
+
+      class IrregularCase1 < OwnershipTest
+        def test_self_run: () -> untyped
+
+        private
+
+        def unknown_wiki_count_list_by_namespace: () -> untyped
+
+        def test_file_maps: () -> untyped
+      end
+
+      class IrregularCase2 < OwnershipTest
+        def test_self_run: () -> untyped
+
+        private
+
+        def unknown_wiki_count_list_by_namespace: () -> untyped
+
+        def test_file_maps: () -> untyped
+      end
+
+      class IrregularCase3 < OwnershipTest
+        def test_self_run: () -> untyped
+
+        private
+
+        def unknown_wiki_count_list_by_namespace: () -> untyped
+
+        def test_file_maps: () -> untyped
+      end
+    end
+
+    class CategoryTest < UnknownWikiCountListExporterTest
+      def setup: () -> untyped
+
+      class RegularCase < CategoryTest
+        def test_self_run: () -> untyped
+
+        private
+
+        def unknown_wiki_count_list_by_namespace: () -> untyped
+      end
+
+      class IrregularCase < CategoryTest
+        def test_self_run: () -> untyped
+
+        private
+
+        def unknown_wiki_count_list_by_namespace: () -> untyped
+
+        def test_file_maps: () -> untyped
+      end
+    end
+  end
+end

--- a/ruby/sig/generated/test/unknown_wiki_list_exporter_for_llm_test.rbs
+++ b/ruby/sig/generated/test/unknown_wiki_list_exporter_for_llm_test.rbs
@@ -1,0 +1,53 @@
+# Generated from test/unknown_wiki_list_exporter_for_llm_test.rb with RBS::Inline
+
+class UnknownWikiListExporterForLLMTest < ApplicationTest
+  def setup: (?group_by: untyped, ?language: untyped) -> untyped
+
+  private
+
+  attr_reader path_to_unknown_wiki_list_for_llm: untyped
+
+  attr_reader unknown_wiki_list_for_llm: untyped
+
+  module English
+    class OwnershipTest < UnknownWikiListExporterForLLMTest
+      def test_self_run: () -> untyped
+
+      private
+
+      def unknown_wiki_list: () -> untyped
+    end
+
+    class CategoryTest < UnknownWikiListExporterForLLMTest
+      def setup: () -> untyped
+
+      def test_self_run: () -> untyped
+
+      private
+
+      def unknown_wiki_list: () -> untyped
+    end
+  end
+
+  module Japanese
+    class OwnershipTest < UnknownWikiListExporterForLLMTest
+      def setup: () -> untyped
+
+      def test_self_run: () -> untyped
+
+      private
+
+      def unknown_wiki_list: () -> untyped
+    end
+
+    class CategoryTest < UnknownWikiListExporterForLLMTest
+      def setup: () -> untyped
+
+      def test_self_run: () -> untyped
+
+      private
+
+      def unknown_wiki_list: () -> untyped
+    end
+  end
+end


### PR DESCRIPTION
## 1. Target PR to Revert

- https://github.com/hayat01sh1da/github-wiki-organisers/pull/47

## 2. Context

Acccording to the article shown below, signrature files should be hosted and ought not to be generated in GitHub Actions workflow because they should be static on a repository.
That is why, `bundle exec rbs-inline --output sig/generated/ .` has been aborted since it generates new signature files and can make differences.

## 3. Reference

- [Rails アプリケーション型付けハンドブック(rbs/steep) > Chapter 04 自前で定義したメソッドの型シグネチャの導入 > 4.4. rbs-inline での出力](https://zenn.dev/sanfrecce_osaka/books/steep-rails-typing-handbook/viewer/introduce-type-signature-for-handwritten-method#4.4.-rbs-inline-での出力)