### PR TITLE
[ruby] Remove Needless FileUtils Import from Codebase

### DIFF
--- a/ruby/src/home.rb
+++ b/ruby/src/home.rb
@@ -1,7 +1,6 @@
 # rbs_inline: enabled
 
 require_relative './application'
-require 'fileutils'
 
 class Home < Application
   HOME_URL = "https://github.com/#{ENV.fetch('ORGANISATION_NAME', 'hayat01sh1da')}/github-wiki-organisers/wiki".freeze

--- a/ruby/test/application_test.rb
+++ b/ruby/test/application_test.rb
@@ -1,7 +1,6 @@
 # rbs_inline: enabled
 
 require 'minitest/autorun'
-require 'fileutils'
 require_relative '../src/application'
 
 class ApplicationTest < Minitest::Test


### PR DESCRIPTION
## Summary

`FileUtils` used to needRuby code to require it with `require 'fileutils'`; however, it has no effect on behaviours.
That is to say, any Ruby script works without it.

⚠️ Steep requires `Steepfile` to declare `library 'fileutils'`; otherwise, type checking fails.