### PR TITLE
[ruby] Add Hidden File Marker to RuboCop Configuration Files on Github Actions Workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,8 +19,8 @@ on:
       - ruby/**/*.rbs
       - ruby/Gemfile
       - ruby/Gemfile.lock
-      - ruby/rubocop.yml
-      - ruby/rubocop_todo.yml
+      - ruby/.rubocop.yml
+      - ruby/.rubocop_todo.yml
       - ruby/Steepfile
   pull_request:
     paths:
@@ -31,8 +31,8 @@ on:
       - ruby/**/*.rbs
       - ruby/Gemfile
       - ruby/Gemfile.lock
-      - ruby/rubocop.yml
-      - ruby/rubocop_todo.yml
+      - ruby/.rubocop.yml
+      - ruby/.rubocop_todo.yml
       - ruby/Steepfile
 
 permissions:
@@ -67,8 +67,8 @@ jobs:
               - ruby/**/*.rb
               - ruby/Gemfile
               - ruby/Gemfile.lock
-              - ruby/rubocop.yml
-              - ruby/rubocop_todo.yml
+              - ruby/.rubocop.yml
+              - ruby/.rubocop_todo.yml
             steep:
               - .github/actions/setup-ruby/action.yml
               - .github/workflows/ruby.yml


### PR DESCRIPTION
## Summary

On Github Actions workflow cofigutration file, RuboCop-related files are assigned as `ruby/rubocop*.yml` to the target paths.
However, they are missing the hidden file marker `.`, which fails to trigger RuboCop workflow.
It should be fixed.