### PR TITLE
[ruby] Transfer Ruby CI Workflow to Bundle Execution with Rakefile

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -90,7 +90,7 @@ jobs:
           job-name: minitest
       - name: Minitest
         working-directory: ./ruby
-        run: ruby test/application_test.rb
+        run: rake
   rubocop:
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -121,13 +121,13 @@ Check it out result on '../../export_unknown_wiki_list_for_llm.txt' !!
 
 ```command
 $ rake
-Run options: --seed 63409
+Run options: --seed 33975
 
 # Running:
 
 ............................................................................................................................................................
 
-Finished in 8.858870s, 17.6095 runs/s, 32.5098 assertions/s.
+Finished in 32.985576s, 4.7293 runs/s, 8.7311 assertions/s.
 
 156 runs, 288 assertions, 0 failures, 0 errors, 0 skips
 ```

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake/testtask'
 task default: :test
 


### PR DESCRIPTION
## Summary

To Guarantee idempotency, it switched to Minitest CI from single file to bulk execution.