### PR TITLE
[python] Migrate to pytest

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -74,7 +74,7 @@ jobs:
       - uses: ./.github/actions/setup-python
       - name: UnitTest
         working-directory: ./python
-        run: python -m unittest discover ./test
+        run: pytest
   # mypy:
   #   timeout-minutes: 10
   #   runs-on: ubuntu-latest

--- a/python/README.md
+++ b/python/README.md
@@ -2,11 +2,17 @@
 
 - Python 3.14.4
 
-## 2. Execution
+## 2. Install Libraries via requirements.txt
+
+```command
+$ pip install -r requirements.txt
+```
+
+## 3. Execution
 
 Run the commands under `./python`
 
-### 2-1. Options
+### 3-1. Options
 
 | Order | Option        | Command-line Argument   |
 | :---- | :------------ | :---------------------- |
@@ -14,7 +20,7 @@ Run the commands under `./python`
 | 2     | language      | `English` or `Japanese` |
 | 3     | home_overflow | `True` or `False`       |
 
-### 2-2. Update Wiki List on Home and Sidebar
+### 3-2. Update Wiki List on Home and Sidebar
 
 ```command
 $ python exec/update_wiki_list_on_home_and_sidebar.py Owner English
@@ -31,9 +37,9 @@ Check out an Up-to-date Wiki List on Sidebar at 'https://github.com/hayat01sh1da
 -------------------- Done Categorising the Entire github-wiki-organisers Wiki Pages 🎉 ---------------------
 ```
 
-## 2-3. Export Unknown Wiki Count List by Namespace
+## 3-3. Export Unknown Wiki Count List by Namespace
 
-### 2-3-1. Owner
+### 3-3-1. Owner
 
 ```command
 $ python exec/export_unknown_wiki_count_list_by_namespace.py Owner English
@@ -69,7 +75,7 @@ Check it out result on '../../unknown_wiki_count_list_by_namespace.txt' !!
 -------------------- Done Exporting Unknown Wiki Count List 🎉 --------------------
 ```
 
-### 2-3-2. Category
+### 3-3-2. Category
 
 ```command
 $ python exec/export_unknown_wiki_count_list_by_namespace.py Category English
@@ -101,7 +107,7 @@ Check it out result on '../../unknown_wiki_count_list_by_namespace.txt' !!
 -------------------- Done Exporting Unknown Wiki Count List 🎉 --------------------
 ```
 
-## 2-4. Export Unknown Wiki List for LLM 
+## 3-4. Export Unknown Wiki List for LLM
 
 ```command
 $ python exec/export_unknown_wiki_list_for_llm.py
@@ -112,13 +118,20 @@ Check it out result on '../../export_unknown_wiki_list_for_llm.txt' !!
 -------------------- Done Exporting Unknown Wiki List 🎉 --------------------
 ```
 
-## 3. Bulk Execution of Unit Tests
+## 4. Bulk Execution of Unit Tests
 
 ```command
-$ python -m unittest discover ./test
-....................................................................................................................................................
-----------------------------------------------------------------------
-Ran 148 tests in 8.722s
+$ pytest
+====================================================================== test session starts =======================================================================
+platform linux -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0
+rootdir: /mnt/c/Users/binlh/Documents/development/github-wiki-organisers/python
+collected 148 items                                                                                                                                              
 
-OK
+test/test_application.py ....                                                                                                                              [  2%]
+test/test_home.py ................................                                                                                                         [ 24%]
+test/test_sidebar.py ........................                                                                                                              [ 40%]
+test/test_unknown_wiki_count_list_exporter.py ................................................................                                             [ 83%]
+test/test_unknown_wiki_list_exporter_for_llm.py ........................                                                                                   [100%]
+
+====================================================================== 148 passed in 12.44s ======================================================================
 ```


### PR DESCRIPTION
## 1. Overview

Pytest is superior to Python’s built-in unittest (and its discover capability) primarily due to its minimal boilerplate code, advanced fixture system for dependency management, and highly readable, simple assert statements.  
It offers superior test discovery, robust plugin support, parameterization, and faster execution via parallel testing.

## 2. Benefits

- **Less Verbose (No Classes Required)**: Pytest allows you to write simple functions to test, whereas `unittest `forces you to organize tests inside classes inheriting from `unittest.TestCase`
- **Simple Assertions**: Instead of `self.assertEqual(a, b)`, you just use Python’s native `assert a == b`. Pytest provides detailed inspection of failed assertions, showing you exactly what went wrong without needing manual error messages
- **Powerful Fixtures**: Pytest’s fixture system is far more modular, scalable, and easier to use for `setup/teardown` than unittest's `setUp/tearDown` methods
- **Parameterization**: Pytest makes it simple to run the same test with different input values using `@pytest.mark.parametrize`, reducing code duplication
- **Massive Plugin Ecosystem**: With hundreds of plugins (e.g., `pytest-cov`, `pytest-django`, `pytest-asyncio`), it is highly extensible, while unittest is limited to built-in functionality
- **Better Test Discovery and Selection**: While `discover `works, `pytest `offers more powerful, intuitive filtering to run specific subsets of tests (by name, marker, or directory)
- **Faster Execution**: Pytest supports running tests in parallel, significantly reducing testing time for large projects

## 3. Summary

In summary, pytest is preferred for its "simple, rapid and fun" approach, significantly reducing the maintenance burden of your test suite.