### PR TITLE
[python] Execute Lint Fixes

### DIFF
--- a/python/exec/export_unknown_wiki_count_list_by_namespace.py
+++ b/python/exec/export_unknown_wiki_count_list_by_namespace.py
@@ -1,19 +1,20 @@
+from unknown_wiki_count_list_exporter import UnknownWikiCountListExporter
 import sys
 import os
 import shutil
 import glob
 sys.path.append('./src')
 
-from unknown_wiki_count_list_exporter import UnknownWikiCountListExporter
 
 _, group_by, language, *_ = sys.argv
 params = dict()
-for key, value in { 'group_by': group_by, 'language': language }.items():
+for key, value in {'group_by': group_by, 'language': language}.items():
     if value:
         params[key] = value
 
 print('-------------------- Exporting Unknown Wiki Count List... --------------------')
-count_list_by_namespace, path_to_export = UnknownWikiCountListExporter(**params).run()
+count_list_by_namespace, path_to_export = UnknownWikiCountListExporter(
+    **params).run()
 print()
 print('Here is the result:')
 print()
@@ -25,6 +26,11 @@ print(f"Check it out result on '{path_to_export}' !!")
 print()
 print('-------------------- Done Exporting Unknown Wiki Count List 🎉 --------------------')
 
-for pycache in glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True):
+for pycache in glob.glob(
+        os.path.join(
+            '.',
+            '**',
+            '__pycache__'),
+        recursive=True):
     if os.path.exists(pycache):
         shutil.rmtree(pycache)

--- a/python/exec/export_unknown_wiki_list_for_llm.py
+++ b/python/exec/export_unknown_wiki_list_for_llm.py
@@ -1,14 +1,14 @@
+from unknown_wiki_list_exporter_for_llm import UnknownWikiListExporterForLLM
 import sys
 import os
 import shutil
 import glob
 sys.path.append('./src')
 
-from unknown_wiki_list_exporter_for_llm import UnknownWikiListExporterForLLM
 
 _, group_by, language, *_ = sys.argv
 params = dict()
-for key, value in { 'group_by': group_by, 'language': language }.items():
+for key, value in {'group_by': group_by, 'language': language}.items():
     if value:
         params[key] = value
 
@@ -19,6 +19,11 @@ print(f"Check it out result on '{path_to_export}' !!")
 print()
 print('-------------------- Done Exporting Unknown Wiki List 🎉 --------------------')
 
-for pycache in glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True):
+for pycache in glob.glob(
+        os.path.join(
+            '.',
+            '**',
+            '__pycache__'),
+        recursive=True):
     if os.path.exists(pycache):
         shutil.rmtree(pycache)

--- a/python/exec/update_wiki_list_on_home_and_sidebar.py
+++ b/python/exec/update_wiki_list_on_home_and_sidebar.py
@@ -1,15 +1,16 @@
+from sidebar import Sidebar
+from home import Home
 import sys
 import os
 import shutil
 import glob
 sys.path.append('./src')
 
-from home import Home
-from sidebar import Sidebar
 
 _, group_by, language, home_overflow, *_ = sys.argv
 params = dict()
-for key, value in { 'group_by': group_by, 'language': language, 'home_overflow': home_overflow }.items():
+for key, value in {'group_by': group_by, 'language': language,
+                   'home_overflow': home_overflow}.items():
     if value:
         params[key] = value
 
@@ -27,6 +28,11 @@ print('-------------------- Done Organising Sidebar 🎉 --------------------')
 print()
 print('-------------------- Done Categorising the Entire github-wiki-organisers Wiki Pages 🎉 --------------------')
 
-for pycache in glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True):
+for pycache in glob.glob(
+        os.path.join(
+            '.',
+            '**',
+            '__pycache__'),
+        recursive=True):
     if os.path.exists(pycache):
         shutil.rmtree(pycache)

--- a/python/requirements.lock
+++ b/python/requirements.lock
@@ -1,8 +1,11 @@
+ast_serialize==0.3.0
+autoflake8==0.4.1
+autopep8==2.3.2
 flake8==7.3.0
 iniconfig==2.3.0
-librt==0.9.0
+librt==0.10.0
 mccabe==0.7.0
-mypy==1.20.2
+mypy==2.0.0
 mypy_extensions==1.1.0
 packaging==26.2
 pathspec==1.1.1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,5 @@
+autoflake8==0.4.1
+autopep8==2.3.2
 flake8==7.3.0
-mypy==1.20.2
+mypy==2.0.0
 pytest==9.0.3

--- a/python/src/application.py
+++ b/python/src/application.py
@@ -3,28 +3,51 @@ import glob
 import re
 from collections import defaultdict
 
+
 class Application:
-    def __init__(self, base_path = os.path.join('..', '..'), group_by = 'Owner', language = 'English', home_overflow = 'False'):
+    def __init__(
+            self,
+            base_path=os.path.join(
+                '..',
+                '..'),
+            group_by='Owner',
+            language='English',
+            home_overflow='False'):
         match home_overflow:
             case 'True':
                 home_overflow = True
             case 'False':
                 home_overflow = False
-        self.__validate__(group_by = group_by, language = language, home_overflow = home_overflow)
-        self.base_path                             = base_path
-        self.group_by                              = group_by
-        self.language                              = language
-        self.home_overflow                         = home_overflow
-        self.path_to_home                          = os.path.join(base_path, 'Home.md')
-        self.path_to_sidebar                       = os.path.join(base_path, '_Sidebar.md')
-        self.path_to_github_wiki_organisers        = sorted(glob.glob(os.path.join(base_path, 'github-wiki-organisers', '**', '*.md')))
-        self.path_to_wikis_by_owner                = sorted(glob.glob(os.path.join(base_path, 'wikis-by-owner', '*.md')))
-        self.target_paths                          = self.__target_paths__()
-        self.wiki_maps_with_namespace              = self.__wiki_maps_with_namespace__()
+        self.__validate__(
+            group_by=group_by,
+            language=language,
+            home_overflow=home_overflow)
+        self.base_path = base_path
+        self.group_by = group_by
+        self.language = language
+        self.home_overflow = home_overflow
+        self.path_to_home = os.path.join(base_path, 'Home.md')
+        self.path_to_sidebar = os.path.join(base_path, '_Sidebar.md')
+        self.path_to_github_wiki_organisers = sorted(
+            glob.glob(
+                os.path.join(
+                    base_path,
+                    'github-wiki-organisers',
+                    '**',
+                    '*.md')))
+        self.path_to_wikis_by_owner = sorted(
+            glob.glob(
+                os.path.join(
+                    base_path,
+                    'wikis-by-owner',
+                    '*.md')))
+        self.target_paths = self.__target_paths__()
+        self.wiki_maps_with_namespace = self.__wiki_maps_with_namespace__()
         self.owned_wiki_maps, self.plain_wiki_maps = self.__filter_namespace__()
 
     def run(self):
-        raise NotImplementedError('This method must be implemented in each subclass.')
+        raise NotImplementedError(
+            'This method must be implemented in each subclass.')
 
     # private
 
@@ -35,11 +58,18 @@ class Application:
         if language not in ['English', 'Japanese']:
             raise ValueError(f'Invalid language: `{language}`')
         if home_overflow not in [True, False]:
-            raise ValueError(f'Invalid home_overflow: `{home_overflow}` must be boolean')
+            raise ValueError(
+                f'Invalid home_overflow: `{home_overflow}` must be boolean')
 
     # @return [str]
     def __target_paths__(self):
-        target_paths = sorted(glob.glob(os.path.join(self.base_path, '**', '*.md'), recursive = True))
+        target_paths = sorted(
+            glob.glob(
+                os.path.join(
+                    self.base_path,
+                    '**',
+                    '*.md'),
+                recursive=True))
 
         for target_path in target_paths:
             match target_path:
@@ -76,8 +106,8 @@ class Application:
 
     # @return [dict<str => list<str>>]
     def __wiki_maps_with_namespace__(self):
-        hash                     = defaultdict(list)
-        uncategrised_wiki_maps   = defaultdict(list)
+        hash = defaultdict(list)
+        uncategrised_wiki_maps = defaultdict(list)
         wiki_maps_with_namespace = defaultdict(list)
 
         for target_path in self.target_paths:
@@ -85,12 +115,15 @@ class Application:
                 continue
 
             with open(target_path) as f:
-                wiki                   = os.path.basename(target_path)
+                wiki = os.path.basename(target_path)
                 _namespace_declaration = f.readlines()
 
-                if _namespace_declaration != [] and re.search(self.__target_regexp__(), _namespace_declaration[0]):
-                    namespace_declaration  = re.sub('\n', '', _namespace_declaration[0])
-                    namespace              = re.sub(self.__target_regexp__(), '', namespace_declaration)
+                if _namespace_declaration != [] and re.search(
+                        self.__target_regexp__(), _namespace_declaration[0]):
+                    namespace_declaration = re.sub(
+                        '\n', '', _namespace_declaration[0])
+                    namespace = re.sub(
+                        self.__target_regexp__(), '', namespace_declaration)
                 else:
                     namespace = self.__no_declaration__()
 

--- a/python/src/home.py
+++ b/python/src/home.py
@@ -1,19 +1,34 @@
+from application import Application
 import sys
 import os
 import re
 import shutil
 sys.path.append('./src')
 
-from application import Application
 
-HOME_URL = f'https://github.com/{os.environ.get('ORGANISATION_NAME', 'hayat01sh1da')}/github-wiki-organisers/wiki'
+HOME_URL = f'https://github.com/{
+    os.environ.get(
+        'ORGANISATION_NAME',
+        'hayat01sh1da')}/github-wiki-organisers/wiki'
+
 
 class Home(Application):
-    def __init__(self, base_path = os.path.join('..', '..'), group_by = 'Owner', language = 'English', home_overflow = False):
+    def __init__(
+            self,
+            base_path=os.path.join(
+                '..',
+                '..'),
+            group_by='Owner',
+            language='English',
+            home_overflow=False):
         super().__init__(base_path, group_by, language, home_overflow)
-        self.base_owner_url         = f'https://github.com/orgs/{os.environ.get('ORGANISATION_NAME', 'hayat01sh1da')}/teams/'
-        self.home_passage           = self.__home_passage__()
-        self.path_to_wikis_by_owner = os.path.join(self.base_path, 'wikis-by-owner')
+        self.base_owner_url = f'https://github.com/orgs/{
+            os.environ.get(
+                'ORGANISATION_NAME',
+                'hayat01sh1da')}/teams/'
+        self.home_passage = self.__home_passage__()
+        self.path_to_wikis_by_owner = os.path.join(
+            self.base_path, 'wikis-by-owner')
 
     def run(self):
         self.__write_home_passage__()
@@ -23,7 +38,9 @@ class Home(Application):
 
     # @return [str]
     def __path_to_home_template__(self):
-        return os.path.join('..', 'home_template', self.group_by.lower(), f'{self.language.lower()}.md')
+        return os.path.join(
+            '..', 'home_template', self.group_by.lower(), f'{
+                self.language.lower()}.md')
 
     # @return [list<str>]
     def __home_passage__(self):
@@ -33,15 +50,21 @@ class Home(Application):
     # @return [str]
     def __write_home_passage__(self):
         if self.home_overflow:
-            os.makedirs(self.path_to_wikis_by_owner, exist_ok = True)
+            os.makedirs(self.path_to_wikis_by_owner, exist_ok=True)
 
             for namespace, wikis in self.owned_wiki_maps.items():
-                self.__write_wikis_by_owner_file__(namespace = namespace, wikis = wikis, owned = True)
+                self.__write_wikis_by_owner_file__(
+                    namespace=namespace, wikis=wikis, owned=True)
 
             for namespace, wikis in self.plain_wiki_maps.items():
-                self.__write_wikis_by_owner_file__(namespace = namespace, wikis = wikis, owned = False)
+                self.__write_wikis_by_owner_file__(
+                    namespace=namespace, wikis=wikis, owned=False)
 
-            for namespace in (list(self.owned_wiki_maps.keys()) + list(self.plain_wiki_maps.keys())):
+            for namespace in (
+                list(
+                    self.owned_wiki_maps.keys()) +
+                list(
+                    self.plain_wiki_maps.keys())):
                 self.home_passage += f'- [[{namespace}]]\n'
 
             self.home_passage += '\n'
@@ -53,7 +76,12 @@ class Home(Application):
             if os.path.exists(self.path_to_wikis_by_owner):
                 shutil.rmtree(self.path_to_wikis_by_owner)
             for namespace, wikis in self.owned_wiki_maps.items():
-                self.home_passage += f'## [{namespace}]({self.base_owner_url + re.sub(r'@', '', namespace)})\n'
+                self.home_passage += f'## [{namespace}]({
+                    self.base_owner_url +
+                    re.sub(
+                        r'@',
+                        '',
+                        namespace)})\n'
                 self.home_passage += '\n'
                 for wiki in wikis:
                     self.home_passage += f'- [[{re.sub(r'\.md', '', wiki)}]]\n'
@@ -70,9 +98,14 @@ class Home(Application):
                 f.write(self.home_passage.rstrip() + '\n')
 
     def __write_wikis_by_owner_file__(self, namespace, wikis, owned):
-        home_passage  = ''
+        home_passage = ''
         if owned:
-            home_passage += f'## [{namespace}]({self.base_owner_url + re.sub(r'@', '', namespace)})\n'
+            home_passage += f'## [{namespace}]({
+                self.base_owner_url +
+                re.sub(
+                    r'@',
+                    '',
+                    namespace)})\n'
         else:
             home_passage += f'## {namespace}\n'
         home_passage += '\n'
@@ -80,6 +113,8 @@ class Home(Application):
             home_passage += f'- [[{re.sub(r'\.md', '', wiki)}]]\n'
         home_passage += '\n'
 
-        file_path = os.path.join(self.path_to_wikis_by_owner, f'{namespace}.md')
+        file_path = os.path.join(
+            self.path_to_wikis_by_owner,
+            f'{namespace}.md')
         with open(file_path, 'w') as f:
             f.write(home_passage.rstrip() + '\n')

--- a/python/src/sidebar.py
+++ b/python/src/sidebar.py
@@ -1,15 +1,25 @@
+from application import Application
 import sys
 import os
 import re
 sys.path.append('./src')
 
-from application import Application
 
 class Sidebar(Application):
-    def __init__(self, base_path = os.path.join('..', '..'), group_by = 'Owner', language = 'English', home_overflow = False):
+    def __init__(
+            self,
+            base_path=os.path.join(
+                '..',
+                '..'),
+            group_by='Owner',
+            language='English',
+            home_overflow=False):
         super().__init__(base_path, group_by, language, home_overflow)
-        self.base_owner_url = f'https://github.com/orgs/{os.environ.get('ORGANISATION_NAME', 'hayat01sh1da')}/teams/'
-        self.wiki_list      = self.__write_wiki_list__()
+        self.base_owner_url = f'https://github.com/orgs/{
+            os.environ.get(
+                'ORGANISATION_NAME',
+                'hayat01sh1da')}/teams/'
+        self.wiki_list = self.__write_wiki_list__()
 
     def run(self):
         with open(self.path_to_sidebar, 'w') as f:
@@ -22,7 +32,8 @@ class Sidebar(Application):
         wiki_list = ''
 
         for namespace, wikis in self.owned_wiki_maps.items():
-            wiki_list += f'- [{namespace}]({self.base_owner_url + re.sub(r'@', '', namespace)})\n'
+            wiki_list += f'- [{namespace}]({self.base_owner_url +
+                                            re.sub(r'@', '', namespace)})\n'
             for wiki in wikis:
                 wiki_list += f'  - [[{re.sub(r'\.md', '', wiki)}]]\n'
 

--- a/python/src/unknown_wiki_count_list_exporter.py
+++ b/python/src/unknown_wiki_count_list_exporter.py
@@ -1,14 +1,23 @@
+from application import Application
 import sys
 import os
 sys.path.append('./src')
 
-from application import Application
 
 class UnknownWikiCountListExporter(Application):
-    def __init__(self, base_path = os.path.join('..', '..'), group_by = 'Owner', language = 'English', home_overflow = False):
+    def __init__(
+            self,
+            base_path=os.path.join(
+                '..',
+                '..'),
+            group_by='Owner',
+            language='English',
+            home_overflow=False):
         super().__init__(base_path, group_by, language, home_overflow)
-        self.path_to_export          = os.path.join(self.base_path, 'unknown_wiki_count_list_by_namespace.txt')
-        self.count_list_by_namespace = ''.join(sorted(self.__count_list_by_namespace__()))
+        self.path_to_export = os.path.join(
+            self.base_path, 'unknown_wiki_count_list_by_namespace.txt')
+        self.count_list_by_namespace = ''.join(
+            sorted(self.__count_list_by_namespace__()))
 
     def run(self):
         with open(self.path_to_export, 'w') as f:
@@ -49,13 +58,15 @@ class UnknownWikiCountListExporter(Application):
     # @return [list<str>]
     def __count_list_by_namespace__(self):
         filtered_count_list_by_namespace = {}
-        count_list_by_namespace          = []
+        count_list_by_namespace = []
 
         for namespace, wikis in self.plain_wiki_maps.items():
             if namespace in self.__namespace_list__():
                 filtered_count_list_by_namespace[namespace] = wikis
 
-        for namespace in (self.__namespace_list__() - filtered_count_list_by_namespace.keys()):
+        for namespace in (
+                self.__namespace_list__() -
+                filtered_count_list_by_namespace.keys()):
             count_list_by_namespace.append(f'{namespace}: 0\n')
 
         for namespace, wikis in filtered_count_list_by_namespace.items():

--- a/python/src/unknown_wiki_list_exporter_for_llm.py
+++ b/python/src/unknown_wiki_list_exporter_for_llm.py
@@ -1,13 +1,23 @@
+from application import Application
 import sys
 import os
 sys.path.append('./src')
-from application import Application
+
 
 class UnknownWikiListExporterForLLM(Application):
-    def __init__(self, base_path = os.path.join('..', '..'), group_by = 'Owner', language = 'English', home_overflow = False):
+    def __init__(
+            self,
+            base_path=os.path.join(
+                '..',
+                '..'),
+            group_by='Owner',
+            language='English',
+            home_overflow=False):
         super().__init__(base_path, group_by, language, home_overflow)
-        self.path_to_export               = os.path.join(self.base_path, 'unknown_wiki_list_for_llm.txt')
-        self.unknown_wiki_list_for_llm = ''.join(sorted(self.__unknown_wiki_list_for_llm__()))
+        self.path_to_export = os.path.join(
+            self.base_path, 'unknown_wiki_list_for_llm.txt')
+        self.unknown_wiki_list_for_llm = ''.join(
+            sorted(self.__unknown_wiki_list_for_llm__()))
 
     def run(self):
         with open(self.path_to_export, 'w') as f:

--- a/python/test/test_application.py
+++ b/python/test/test_application.py
@@ -1,3 +1,4 @@
+from application import Application
 import sys
 import unittest
 import os
@@ -5,16 +6,28 @@ import glob
 import shutil
 sys.path.append('./src')
 
-from application import Application
 
 class TestApplication(unittest.TestCase):
-    def setUp(self, base_path = os.path.join('.', 'test', 'wiki'), group_by = 'Owner', language = 'English', home_overflow = False):
-        self.base_path      = base_path
-        self.group_by       = group_by
-        self.language       = language
-        self.home_overflow  = home_overflow
-        self.pycaches  = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
-        os.makedirs(self.base_path, exist_ok = True)
+    def setUp(
+            self,
+            base_path=os.path.join(
+                '.',
+                'test',
+                'wiki'),
+            group_by='Owner',
+            language='English',
+            home_overflow=False):
+        self.base_path = base_path
+        self.group_by = group_by
+        self.language = language
+        self.home_overflow = home_overflow
+        self.pycaches = glob.glob(
+            os.path.join(
+                '.',
+                '**',
+                '__pycache__'),
+            recursive=True)
+        os.makedirs(self.base_path, exist_ok=True)
         for wiki, namespace in self.__test_file_maps__().items():
             with open(os.path.join(self.base_path, wiki), 'w') as f:
                 f.write(namespace)
@@ -28,28 +41,43 @@ class TestApplication(unittest.TestCase):
 
     def test_validate_group_by(self):
         with self.assertRaises(ValueError) as cm:
-            Application(base_path = self.base_path, group_by = 'Group', language = self.language, home_overflow = self.home_overflow)
+            Application(
+                base_path=self.base_path,
+                group_by='Group',
+                language=self.language,
+                home_overflow=self.home_overflow)
         self.assertEqual(str(cm.exception), 'Invalid group_by: `Group`')
 
     def test_validate_language(self):
         with self.assertRaises(ValueError) as cm:
-            Application(base_path = self.base_path, group_by = self.group_by, language = 'Spanish', home_overflow = self.home_overflow)
+            Application(
+                base_path=self.base_path,
+                group_by=self.group_by,
+                language='Spanish',
+                home_overflow=self.home_overflow)
         self.assertEqual(str(cm.exception), 'Invalid language: `Spanish`')
 
     def test_validate_home_overflow(self):
         with self.assertRaises(ValueError) as cm:
-            Application(base_path = self.base_path, group_by = self.group_by, language = self.language, home_overflow = 'foo')
-        self.assertEqual(str(cm.exception), 'Invalid home_overflow: `foo` must be boolean')
+            Application(
+                base_path=self.base_path,
+                group_by=self.group_by,
+                language=self.language,
+                home_overflow='foo')
+        self.assertEqual(str(cm.exception),
+                         'Invalid home_overflow: `foo` must be boolean')
 
     def test_run(self):
         with self.assertRaises(NotImplementedError) as cm:
             Application(
-                base_path     = self.base_path,
-                group_by      = self.group_by,
-                language      = self.language,
-                home_overflow = self.home_overflow,
+                base_path=self.base_path,
+                group_by=self.group_by,
+                language=self.language,
+                home_overflow=self.home_overflow,
             ).run()
-        self.assertEqual('This method must be implemented in each subclass.', str(cm.exception))
+        self.assertEqual(
+            'This method must be implemented in each subclass.', str(
+                cm.exception))
 
     # private
 
@@ -63,16 +91,14 @@ class TestApplication(unittest.TestCase):
                             'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
                             'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
                             'Unowned Wiki 1.md': '',
-                            'Unowned Wiki 2.md': 'This is a sample Wiki'
-                        }
+                            'Unowned Wiki 2.md': 'This is a sample Wiki'}
                     case 'Japanese':
                         return {
                             'Owner記名ありページ.md': 'Owner: @test-owner',
                             'Ownerチームが不明だが必要なページ.md': 'Owner: Ownerチームが不明だが必要なページ群',
                             'Ownerチーム・要or不要が不明なページ.md': 'Owner: Ownerチーム・要or不要が不明なページ群',
                             'Owner記名なしページ1.md': '',
-                            'Owner記名なしページ2.md': 'サンプル Wiki'
-                        }
+                            'Owner記名なしページ2.md': 'サンプル Wiki'}
             case 'Category':
                 match self.language:
                     case 'English':
@@ -87,6 +113,7 @@ class TestApplication(unittest.TestCase):
                             'Category記載なしページ1.md': '',
                             'Category記載なしページ2.md': 'サンプル Wiki'
                         }
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test_application.py
+++ b/python/test/test_application.py
@@ -1,10 +1,10 @@
-from application import Application
 import sys
 import unittest
 import os
 import glob
 import shutil
 sys.path.append('./src')
+from application import Application
 
 
 class TestApplication(unittest.TestCase):

--- a/python/test/test_home.py
+++ b/python/test/test_home.py
@@ -1,3 +1,5 @@
+from test_application import TestApplication
+from home import Home
 import sys
 import os
 import glob
@@ -5,21 +7,30 @@ import unittest
 sys.path.append('./src')
 sys.path.append('./test')
 
-from home import Home
-from test_application import TestApplication
 
 class TestHome(TestApplication):
-    def setUp(self, group_by = 'Owner', language = 'English', home_overflow = False):
-        super().setUp(group_by = group_by, language = language, home_overflow = home_overflow)
-        Home(base_path = self.base_path, group_by = group_by, language = language, home_overflow = home_overflow).run()
+    def setUp(self, group_by='Owner', language='English', home_overflow=False):
+        super().setUp(group_by=group_by, language=language, home_overflow=home_overflow)
+        Home(
+            base_path=self.base_path,
+            group_by=group_by,
+            language=language,
+            home_overflow=home_overflow).run()
         path_to_home = os.path.join(self.base_path, 'Home.md')
         with open(path_to_home) as f:
             self.home = f.read()
-        self.path_to_wikis_by_owner = os.path.join(self.base_path, 'wikis-by-owner')
-        self.overflow_files         = sorted(glob.glob(os.path.join(self.path_to_wikis_by_owner, '*.md')))
+        self.path_to_wikis_by_owner = os.path.join(
+            self.base_path, 'wikis-by-owner')
+        self.overflow_files = sorted(
+            glob.glob(
+                os.path.join(
+                    self.path_to_wikis_by_owner,
+                    '*.md')))
 
     def __expected_wikis_by_owner__(self, namespaces):
-        return sorted([os.path.join(self.path_to_wikis_by_owner, f'{namespace}.md') for namespace in namespaces])
+        return sorted([os.path.join(self.path_to_wikis_by_owner,
+                      f'{namespace}.md') for namespace in namespaces])
+
 
 class EnglishOwnedHomeWithoutOverflowTest(TestHome):
     def test_run(self):
@@ -29,7 +40,7 @@ class EnglishOwnedHomeWithoutOverflowTest(TestHome):
     # private
 
     def __home_passage__(self):
-        passage  = '## How to Manage Wiki Pages\n'
+        passage = '## How to Manage Wiki Pages\n'
         passage += '\n'
         passage += 'This Home page manage wikis by owner group.\n'
         passage += '\n'
@@ -57,20 +68,22 @@ class EnglishOwnedHomeWithoutOverflowTest(TestHome):
 
         return passage
 
+
 class EnglishOwnedHomeWithOverflowTest(TestHome):
     def setUp(self):
-        super().setUp(home_overflow = True)
+        super().setUp(home_overflow=True)
 
     def test_run(self):
         self.assertTrue(os.path.exists(self.path_to_wikis_by_owner))
         self.assertEqual(self.home, self.__home_passage__())
-        expected_files = self.__expected_wikis_by_owner__(['@test-owner', 'Unknown Owner nor Necessity', 'Unowned but Necessary', 'Unowned'])
+        expected_files = self.__expected_wikis_by_owner__(
+            ['@test-owner', 'Unknown Owner nor Necessity', 'Unowned but Necessary', 'Unowned'])
         self.assertEqual(self.overflow_files, expected_files)
 
     # private
 
     def __home_passage__(self):
-        passage  = '## How to Manage Wiki Pages\n'
+        passage = '## How to Manage Wiki Pages\n'
         passage += '\n'
         passage += 'This Home page manage wikis by owner group.\n'
         passage += '\n'
@@ -86,9 +99,10 @@ class EnglishOwnedHomeWithOverflowTest(TestHome):
 
         return passage
 
+
 class EnglishCategorisedHomeTest(TestHome):
     def setUp(self):
-        super().setUp(group_by = 'Category')
+        super().setUp(group_by='Category')
 
     def test_run(self):
         self.assertEqual(self.home, self.__home_passage__())
@@ -96,7 +110,7 @@ class EnglishCategorisedHomeTest(TestHome):
     # private
 
     def __home_passage__(self):
-        passage  = '## How to Manage Wiki Pages\n'
+        passage = '## How to Manage Wiki Pages\n'
         passage += '\n'
         passage += 'This Home page manage wikis by category group.\n'
         passage += '\n'
@@ -116,9 +130,10 @@ class EnglishCategorisedHomeTest(TestHome):
 
         return passage
 
+
 class JapaneseOwnedHomeWithoutOverflowTest(TestHome):
     def setUp(self):
-        super().setUp(language = 'Japanese')
+        super().setUp(language='Japanese')
 
     def test_run(self):
         self.assertFalse(os.path.exists(self.path_to_wikis_by_owner))
@@ -127,7 +142,7 @@ class JapaneseOwnedHomeWithoutOverflowTest(TestHome):
     # private
 
     def __home_passage__(self):
-        passage  = '## Wiki ページの運用ルール\n'
+        passage = '## Wiki ページの運用ルール\n'
         passage += '\n'
         passage += 'このページは Owner チームごとに Wiki をグルーピングして一覧化しています。\n'
         passage += '\n'
@@ -155,20 +170,22 @@ class JapaneseOwnedHomeWithoutOverflowTest(TestHome):
 
         return passage
 
+
 class JapaneseOwnedHomeWihOverflowTest(TestHome):
     def setUp(self):
-        super().setUp(language = 'Japanese', home_overflow = True)
+        super().setUp(language='Japanese', home_overflow=True)
 
     def test_run(self):
         self.assertTrue(os.path.exists(self.path_to_wikis_by_owner))
         self.assertEqual(self.home, self.__home_passage__())
-        expected_files = self.__expected_wikis_by_owner__(['@test-owner', 'Ownerチームが不明だが必要なページ群', 'Ownerチーム・要or不要が不明なページ群', 'Owner記名なし'])
+        expected_files = self.__expected_wikis_by_owner__(
+            ['@test-owner', 'Ownerチームが不明だが必要なページ群', 'Ownerチーム・要or不要が不明なページ群', 'Owner記名なし'])
         self.assertEqual(self.overflow_files, expected_files)
 
     # private
 
     def __home_passage__(self):
-        passage  = '## Wiki ページの運用ルール\n'
+        passage = '## Wiki ページの運用ルール\n'
         passage += '\n'
         passage += 'このページは Owner チームごとに Wiki をグルーピングして一覧化しています。\n'
         passage += '\n'
@@ -184,9 +201,10 @@ class JapaneseOwnedHomeWihOverflowTest(TestHome):
 
         return passage
 
+
 class JapaneseCategorisedHomeTest(TestHome):
     def setUp(self):
-        super().setUp(group_by = 'Category', language = 'Japanese')
+        super().setUp(group_by='Category', language='Japanese')
 
     def test_run(self):
         self.assertEqual(self.home, self.__home_passage__())
@@ -194,7 +212,7 @@ class JapaneseCategorisedHomeTest(TestHome):
     # private
 
     def __home_passage__(self):
-        passage  = '## Wiki ページの運用ルール\n'
+        passage = '## Wiki ページの運用ルール\n'
         passage += '\n'
         passage += 'このページは Category ごとに Wiki をグルーピングして一覧化しています。\n'
         passage += '\n'
@@ -213,6 +231,7 @@ class JapaneseCategorisedHomeTest(TestHome):
         passage += '- [[Category記載なしページ2]]\n'
 
         return passage
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test_home.py
+++ b/python/test/test_home.py
@@ -1,4 +1,3 @@
-from test_application import TestApplication
 from home import Home
 import sys
 import os
@@ -6,6 +5,7 @@ import glob
 import unittest
 sys.path.append('./src')
 sys.path.append('./test')
+from test_application import TestApplication
 
 
 class TestHome(TestApplication):

--- a/python/test/test_sidebar.py
+++ b/python/test/test_sidebar.py
@@ -1,10 +1,10 @@
-from test_application import TestApplication
 from sidebar import Sidebar
 import sys
 import os
 import unittest
 sys.path.append('./src')
 sys.path.append('./test')
+from test_application import TestApplication
 
 
 class TestSidebar(TestApplication):

--- a/python/test/test_sidebar.py
+++ b/python/test/test_sidebar.py
@@ -1,19 +1,20 @@
+from test_application import TestApplication
+from sidebar import Sidebar
 import sys
 import os
 import unittest
 sys.path.append('./src')
 sys.path.append('./test')
 
-from sidebar import Sidebar
-from test_application import TestApplication
 
 class TestSidebar(TestApplication):
-    def setUp(self, group_by = 'Owner', language = 'English'):
-        super().setUp(group_by = group_by, language = language)
-        Sidebar(self.base_path, group_by = group_by, language = language).run()
+    def setUp(self, group_by='Owner', language='English'):
+        super().setUp(group_by=group_by, language=language)
+        Sidebar(self.base_path, group_by=group_by, language=language).run()
         path_to_sidebar = os.path.join(self.base_path, '_Sidebar.md')
         with open(path_to_sidebar) as f:
             self.sidebar = f.read()
+
 
 class EnglishOwnedSidebarTest(TestSidebar):
     def test_run(self):
@@ -22,7 +23,7 @@ class EnglishOwnedSidebarTest(TestSidebar):
     # private
 
     def __wiki_list__(self):
-        lst  = '- [@test-owner](https://github.com/orgs/hayat01sh1da/teams/test-owner)\n'
+        lst = '- [@test-owner](https://github.com/orgs/hayat01sh1da/teams/test-owner)\n'
         lst += '  - [[Owned Wiki]]\n'
         lst += '- Unknown Owner nor Necessity\n'
         lst += '  - [[Unknown Owner nor Necessity Wiki]]\n'
@@ -34,9 +35,10 @@ class EnglishOwnedSidebarTest(TestSidebar):
 
         return lst
 
+
 class EnglishPlainSidebarTest(TestSidebar):
     def setUp(self):
-        super().setUp(group_by = 'Category')
+        super().setUp(group_by='Category')
 
     def test_run(self):
         self.assertEqual(self.sidebar, self.__wiki_list__())
@@ -44,7 +46,7 @@ class EnglishPlainSidebarTest(TestSidebar):
     # private
 
     def __wiki_list__(self):
-        lst  = '- test-category\n'
+        lst = '- test-category\n'
         lst += '  - [[Categorised Wiki]]\n'
         lst += '- Uncategorised\n'
         lst += '  - [[Uncategorised Wiki 1]]\n'
@@ -52,9 +54,10 @@ class EnglishPlainSidebarTest(TestSidebar):
 
         return lst
 
+
 class JapaneseOwnedSidebarTest(TestSidebar):
     def setUp(self):
-        super().setUp(language = 'Japanese')
+        super().setUp(language='Japanese')
 
     def test_run(self):
         self.assertEqual(self.sidebar, self.__wiki_list__())
@@ -62,7 +65,7 @@ class JapaneseOwnedSidebarTest(TestSidebar):
     # private
 
     def __wiki_list__(self):
-        lst  = '- [@test-owner](https://github.com/orgs/hayat01sh1da/teams/test-owner)\n'
+        lst = '- [@test-owner](https://github.com/orgs/hayat01sh1da/teams/test-owner)\n'
         lst += '  - [[Owner記名ありページ]]\n'
         lst += '- Ownerチームが不明だが必要なページ群\n'
         lst += '  - [[Ownerチームが不明だが必要なページ]]\n'
@@ -73,9 +76,11 @@ class JapaneseOwnedSidebarTest(TestSidebar):
         lst += '  - [[Owner記名なしページ2]]\n'
 
         return lst
+
+
 class JapanesePlainSidebarTest(TestSidebar):
     def setUp(self):
-        super().setUp(group_by = 'Category', language = 'Japanese')
+        super().setUp(group_by='Category', language='Japanese')
 
     def test_run(self):
         self.assertEqual(self.sidebar, self.__wiki_list__())
@@ -83,13 +88,14 @@ class JapanesePlainSidebarTest(TestSidebar):
     # private
 
     def __wiki_list__(self):
-        lst  = '- test-category\n'
+        lst = '- test-category\n'
         lst += '  - [[Category記載ありページ]]\n'
         lst += '- Category記載なし\n'
         lst += '  - [[Category記載なしページ1]]\n'
         lst += '  - [[Category記載なしページ2]]\n'
 
         return lst
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test_unknown_wiki_count_list_exporter.py
+++ b/python/test/test_unknown_wiki_count_list_exporter.py
@@ -1,41 +1,49 @@
+from test_application import TestApplication
+from unknown_wiki_count_list_exporter import UnknownWikiCountListExporter
 import sys
 import os
 import unittest
 sys.path.append('./src')
 sys.path.append('./test')
 
-from unknown_wiki_count_list_exporter import UnknownWikiCountListExporter
-from test_application import TestApplication
 
 class TestUnknownWikiCountListExporter(TestApplication):
-    def setUp(self, group_by = 'Owner', language = 'English'):
-        super().setUp(group_by = group_by, language = language)
-        UnknownWikiCountListExporter(self.base_path, group_by = group_by, language = language).run()
-        path_to_unknown_wiki_count_list = os.path.join(self.base_path, 'unknown_wiki_count_list_by_namespace.txt')
+    def setUp(self, group_by='Owner', language='English'):
+        super().setUp(group_by=group_by, language=language)
+        UnknownWikiCountListExporter(
+            self.base_path,
+            group_by=group_by,
+            language=language).run()
+        path_to_unknown_wiki_count_list = os.path.join(
+            self.base_path, 'unknown_wiki_count_list_by_namespace.txt')
         with open(path_to_unknown_wiki_count_list) as f:
             self.unknown_wiki_count_list = f.read()
 
+
 class EnglishOwnerTestRegularCase1(TestUnknownWikiCountListExporter):
     def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list, self.__unknown_wiki_count_list_by_namespace__())
+        self.assertEqual(self.unknown_wiki_count_list,
+                         self.__unknown_wiki_count_list_by_namespace__())
 
     # private
 
     def __unknown_wiki_count_list_by_namespace__(self):
-        lst  = 'Unknown Owner nor Necessity: 1\n'
+        lst = 'Unknown Owner nor Necessity: 1\n'
         lst += 'Unowned but Necessary: 1\n'
         lst += 'Unowned: 2\n'
 
         return lst
 
+
 class EnglishOwnerTestRegularCase2(TestUnknownWikiCountListExporter):
     def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list, self.__unknown_wiki_count_list_by_namespace__())
+        self.assertEqual(self.unknown_wiki_count_list,
+                         self.__unknown_wiki_count_list_by_namespace__())
 
     # private
 
     def __unknown_wiki_count_list_by_namespace__(self):
-        lst  = 'Unknown Owner nor Necessity: 1\n'
+        lst = 'Unknown Owner nor Necessity: 1\n'
         lst += 'Unowned but Necessary: 1\n'
         lst += 'Unowned: 2\n'
 
@@ -46,17 +54,18 @@ class EnglishOwnerTestRegularCase2(TestUnknownWikiCountListExporter):
             'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
             'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
             'Unowned Wiki 1.md': '',
-            'Unowned Wiki 2.md': 'This is a sample Wiki'
-        }
+            'Unowned Wiki 2.md': 'This is a sample Wiki'}
+
 
 class EnglishOwnerTestIrregularCase1(TestUnknownWikiCountListExporter):
     def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list, self.__unknown_wiki_count_list_by_namespace__())
+        self.assertEqual(self.unknown_wiki_count_list,
+                         self.__unknown_wiki_count_list_by_namespace__())
 
     # private
 
     def __unknown_wiki_count_list_by_namespace__(self):
-        lst  = 'Unknown Owner nor Necessity: 0\n'
+        lst = 'Unknown Owner nor Necessity: 0\n'
         lst += 'Unowned but Necessary: 1\n'
         lst += 'Unowned: 2\n'
 
@@ -70,14 +79,16 @@ class EnglishOwnerTestIrregularCase1(TestUnknownWikiCountListExporter):
             'Unowned Wiki 2.md': 'This is a sample Wiki'
         }
 
+
 class EnglishOwnerTestIrregularCase2(TestUnknownWikiCountListExporter):
     def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list, self.__unknown_wiki_count_list_by_namespace__())
+        self.assertEqual(self.unknown_wiki_count_list,
+                         self.__unknown_wiki_count_list_by_namespace__())
 
     # private
 
     def __unknown_wiki_count_list_by_namespace__(self):
-        lst  = 'Unknown Owner nor Necessity: 1\n'
+        lst = 'Unknown Owner nor Necessity: 1\n'
         lst += 'Unowned but Necessary: 0\n'
         lst += 'Unowned: 2\n'
 
@@ -88,17 +99,18 @@ class EnglishOwnerTestIrregularCase2(TestUnknownWikiCountListExporter):
             'Owned Wiki.md': 'Owner: @test-owner',
             'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
             'Unowned Wiki 1.md': '',
-            'Unowned Wiki 2.md': 'This is a sample Wiki'
-        }
+            'Unowned Wiki 2.md': 'This is a sample Wiki'}
+
 
 class EnglishOwnerTestIrregularCase3(TestUnknownWikiCountListExporter):
     def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list, self.__unknown_wiki_count_list_by_namespace__())
+        self.assertEqual(self.unknown_wiki_count_list,
+                         self.__unknown_wiki_count_list_by_namespace__())
 
     # private
 
     def __unknown_wiki_count_list_by_namespace__(self):
-        lst  = 'Unknown Owner nor Necessity: 1\n'
+        lst = 'Unknown Owner nor Necessity: 1\n'
         lst += 'Unowned but Necessary: 1\n'
         lst += 'Unowned: 0\n'
 
@@ -111,24 +123,28 @@ class EnglishOwnerTestIrregularCase3(TestUnknownWikiCountListExporter):
             'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
         }
 
+
 class EnglishCategoryTestRegularCase(TestUnknownWikiCountListExporter):
     def setUp(self):
-        super().setUp(group_by = 'Category')
+        super().setUp(group_by='Category')
 
     def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list, self.__unknown_wiki_count_list_by_namespace__())
+        self.assertEqual(self.unknown_wiki_count_list,
+                         self.__unknown_wiki_count_list_by_namespace__())
 
     # private
 
     def __unknown_wiki_count_list_by_namespace__(self):
         return 'Uncategorised: 2\n'
 
+
 class EnglishCategoryTestIrregularCase(TestUnknownWikiCountListExporter):
     def setUp(self):
-        super().setUp(group_by = 'Category')
+        super().setUp(group_by='Category')
 
     def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list, self.__unknown_wiki_count_list_by_namespace__())
+        self.assertEqual(self.unknown_wiki_count_list,
+                         self.__unknown_wiki_count_list_by_namespace__())
 
     # private
 
@@ -143,36 +159,39 @@ class EnglishCategoryTestIrregularCase(TestUnknownWikiCountListExporter):
             'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
             'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
             'Unowned Wiki 1.md': '',
-            'Unowned Wiki 2.md': 'This is a sample Wiki'
-        }
+            'Unowned Wiki 2.md': 'This is a sample Wiki'}
+
 
 class JapaneseOwnerTestRegularCase1(TestUnknownWikiCountListExporter):
     def setUp(self):
-        super().setUp(language = 'Japanese')
+        super().setUp(language='Japanese')
 
     def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list, self.__unknown_wiki_count_list_by_namespace__())
+        self.assertEqual(self.unknown_wiki_count_list,
+                         self.__unknown_wiki_count_list_by_namespace__())
 
     # private
 
     def __unknown_wiki_count_list_by_namespace__(self):
-        lst  = 'Ownerチームが不明だが必要なページ群: 1\n'
+        lst = 'Ownerチームが不明だが必要なページ群: 1\n'
         lst += 'Ownerチーム・要or不要が不明なページ群: 1\n'
         lst += 'Owner記名なし: 2\n'
 
         return lst
 
+
 class JapaneseOwnerTestRegularCase2(TestUnknownWikiCountListExporter):
     def setUp(self):
-        super().setUp(language = 'Japanese')
+        super().setUp(language='Japanese')
 
     def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list, self.__unknown_wiki_count_list_by_namespace__())
+        self.assertEqual(self.unknown_wiki_count_list,
+                         self.__unknown_wiki_count_list_by_namespace__())
 
     # private
 
     def __unknown_wiki_count_list_by_namespace__(self):
-        lst  = 'Ownerチームが不明だが必要なページ群: 1\n'
+        lst = 'Ownerチームが不明だが必要なページ群: 1\n'
         lst += 'Ownerチーム・要or不要が不明なページ群: 1\n'
         lst += 'Owner記名なし: 2\n'
 
@@ -186,17 +205,19 @@ class JapaneseOwnerTestRegularCase2(TestUnknownWikiCountListExporter):
             'Owner記名なしページ2.md': 'サンプル Wiki'
         }
 
+
 class JapaneseOwnerTestIrregularCase1(TestUnknownWikiCountListExporter):
     def setUp(self):
-        super().setUp(language = 'Japanese')
+        super().setUp(language='Japanese')
 
     def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list, self.__unknown_wiki_count_list_by_namespace__())
+        self.assertEqual(self.unknown_wiki_count_list,
+                         self.__unknown_wiki_count_list_by_namespace__())
 
     # private
 
     def __unknown_wiki_count_list_by_namespace__(self):
-        lst  = 'Ownerチームが不明だが必要なページ群: 1\n'
+        lst = 'Ownerチームが不明だが必要なページ群: 1\n'
         lst += 'Ownerチーム・要or不要が不明なページ群: 0\n'
         lst += 'Owner記名なし: 2\n'
 
@@ -210,17 +231,19 @@ class JapaneseOwnerTestIrregularCase1(TestUnknownWikiCountListExporter):
             'Owner記名なしページ2.md': 'サンプル Wiki'
         }
 
+
 class JapaneseOwnerTestIrregularCase2(TestUnknownWikiCountListExporter):
     def setUp(self):
-        super().setUp(language = 'Japanese')
+        super().setUp(language='Japanese')
 
     def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list, self.__unknown_wiki_count_list_by_namespace__())
+        self.assertEqual(self.unknown_wiki_count_list,
+                         self.__unknown_wiki_count_list_by_namespace__())
 
     # private
 
     def __unknown_wiki_count_list_by_namespace__(self):
-        lst  = 'Ownerチームが不明だが必要なページ群: 0\n'
+        lst = 'Ownerチームが不明だが必要なページ群: 0\n'
         lst += 'Ownerチーム・要or不要が不明なページ群: 1\n'
         lst += 'Owner記名なし: 2\n'
 
@@ -234,17 +257,19 @@ class JapaneseOwnerTestIrregularCase2(TestUnknownWikiCountListExporter):
             'Owner記名なしページ2.md': 'サンプル Wiki'
         }
 
+
 class JapaneseOwnerTestIrregularCase3(TestUnknownWikiCountListExporter):
     def setUp(self):
-        super().setUp(language = 'Japanese')
+        super().setUp(language='Japanese')
 
     def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list, self.__unknown_wiki_count_list_by_namespace__())
+        self.assertEqual(self.unknown_wiki_count_list,
+                         self.__unknown_wiki_count_list_by_namespace__())
 
     # private
 
     def __unknown_wiki_count_list_by_namespace__(self):
-        lst  = 'Ownerチームが不明だが必要なページ群: 1\n'
+        lst = 'Ownerチームが不明だが必要なページ群: 1\n'
         lst += 'Ownerチーム・要or不要が不明なページ群: 1\n'
         lst += 'Owner記名なし: 0\n'
 
@@ -257,24 +282,28 @@ class JapaneseOwnerTestIrregularCase3(TestUnknownWikiCountListExporter):
             'Ownerチーム・要or不要が不明なページ.md': 'Owner: Ownerチーム・要or不要が不明なページ群',
         }
 
+
 class JapaneseCategoryTestRegularCase(TestUnknownWikiCountListExporter):
     def setUp(self):
-        super().setUp(group_by = 'Category', language = 'Japanese')
+        super().setUp(group_by='Category', language='Japanese')
 
     def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list, self.__unknown_wiki_count_list_by_namespace__())
+        self.assertEqual(self.unknown_wiki_count_list,
+                         self.__unknown_wiki_count_list_by_namespace__())
 
     # private
 
     def __unknown_wiki_count_list_by_namespace__(self):
         return 'Category記載なし: 2\n'
 
+
 class JapaneseCategoryTestIrregularCase(TestUnknownWikiCountListExporter):
     def setUp(self):
-        super().setUp(group_by = 'Category', language = 'Japanese')
+        super().setUp(group_by='Category', language='Japanese')
 
     def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list, self.__unknown_wiki_count_list_by_namespace__())
+        self.assertEqual(self.unknown_wiki_count_list,
+                         self.__unknown_wiki_count_list_by_namespace__())
 
     # private
 
@@ -291,6 +320,7 @@ class JapaneseCategoryTestIrregularCase(TestUnknownWikiCountListExporter):
             'Owner記名なしページ1.md': '',
             'Owner記名なしページ2.md': 'サンプル Wiki'
         }
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test_unknown_wiki_count_list_exporter.py
+++ b/python/test/test_unknown_wiki_count_list_exporter.py
@@ -1,10 +1,10 @@
-from test_application import TestApplication
 from unknown_wiki_count_list_exporter import UnknownWikiCountListExporter
 import sys
 import os
 import unittest
 sys.path.append('./src')
 sys.path.append('./test')
+from test_application import TestApplication
 
 
 class TestUnknownWikiCountListExporter(TestApplication):

--- a/python/test/test_unknown_wiki_list_exporter_for_llm.py
+++ b/python/test/test_unknown_wiki_list_exporter_for_llm.py
@@ -1,10 +1,10 @@
-from test_application import TestApplication
 from unknown_wiki_list_exporter_for_llm import UnknownWikiListExporterForLLM
 import sys
 import os
 import unittest
 sys.path.append('./src')
 sys.path.append('./test')
+from test_application import TestApplication
 
 
 class TestUnknownWikiListExporterForLLM(TestApplication):

--- a/python/test/test_unknown_wiki_list_exporter_for_llm.py
+++ b/python/test/test_unknown_wiki_list_exporter_for_llm.py
@@ -1,34 +1,45 @@
+from test_application import TestApplication
+from unknown_wiki_list_exporter_for_llm import UnknownWikiListExporterForLLM
 import sys
 import os
 import unittest
 sys.path.append('./src')
 sys.path.append('./test')
-from unknown_wiki_list_exporter_for_llm import UnknownWikiListExporterForLLM
-from test_application import TestApplication
+
 
 class TestUnknownWikiListExporterForLLM(TestApplication):
-    def setUp(self, group_by = 'Owner', language = 'English'):
-        super().setUp(group_by = group_by, language = language)
-        UnknownWikiListExporterForLLM(base_path = self.base_path, group_by = group_by, language = language).run()
-        path_to_unknown_wiki_list_for_llm = os.path.join(self.base_path, 'unknown_wiki_list_for_llm.txt')
+    def setUp(self, group_by='Owner', language='English'):
+        super().setUp(group_by=group_by, language=language)
+        UnknownWikiListExporterForLLM(
+            base_path=self.base_path,
+            group_by=group_by,
+            language=language).run()
+        path_to_unknown_wiki_list_for_llm = os.path.join(
+            self.base_path, 'unknown_wiki_list_for_llm.txt')
         with open(path_to_unknown_wiki_list_for_llm) as f:
             self.unknown_wiki_list_for_llm = f.read()
 
+
 class EnglishOwnershipTest(TestUnknownWikiListExporterForLLM):
     def test_run(self):
-        self.assertEqual(self.unknown_wiki_list_for_llm, self.__unknown_wiki_list_for_llm__())
+        self.assertEqual(
+            self.unknown_wiki_list_for_llm,
+            self.__unknown_wiki_list_for_llm__())
 
     # private
 
     def __unknown_wiki_list_for_llm__(self):
         return 'Unknown Owner nor Necessity Wiki.md\n'
 
+
 class EnglishCategoryTest(TestUnknownWikiListExporterForLLM):
     def setUp(self):
-        super().setUp(group_by = 'Category')
+        super().setUp(group_by='Category')
 
     def test_run(self):
-        self.assertEqual(self.unknown_wiki_list_for_llm, ''.join(self.__unknown_wiki_list_for_llm__()))
+        self.assertEqual(
+            self.unknown_wiki_list_for_llm, ''.join(
+                self.__unknown_wiki_list_for_llm__()))
 
     # private
 
@@ -40,24 +51,30 @@ class EnglishCategoryTest(TestUnknownWikiListExporterForLLM):
 
         return lst
 
+
 class JapaneseOwnershipTest(TestUnknownWikiListExporterForLLM):
     def setUp(self):
-        super().setUp(language = 'Japanese')
+        super().setUp(language='Japanese')
 
     def test_run(self):
-        self.assertEqual(self.unknown_wiki_list_for_llm, self.__unknown_wiki_list_for_llm__())
+        self.assertEqual(
+            self.unknown_wiki_list_for_llm,
+            self.__unknown_wiki_list_for_llm__())
 
     # private
 
     def __unknown_wiki_list_for_llm__(self):
         return 'Ownerチーム・要or不要が不明なページ.md\n'
 
+
 class JapaneseCategoryTest(TestUnknownWikiListExporterForLLM):
     def setUp(self):
-        super().setUp(group_by = 'Category', language = 'Japanese')
+        super().setUp(group_by='Category', language='Japanese')
 
     def test_run(self):
-        self.assertEqual(self.unknown_wiki_list_for_llm, ''.join(self.__unknown_wiki_list_for_llm__()))
+        self.assertEqual(
+            self.unknown_wiki_list_for_llm, ''.join(
+                self.__unknown_wiki_list_for_llm__()))
 
     # private
 
@@ -68,6 +85,7 @@ class JapaneseCategoryTest(TestUnknownWikiListExporterForLLM):
         ]
 
         return lst
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## 1. Overview

This project makes use of [flake8](https://pypi.org/project/flake8/) as an inspector of violations against Python syntax and convention.
However, it does not fix them, so some other libraries need installing, which are [autoflake8](https://pypi.org/project/autoflake8/) and [autopep8](https://pypi.org/project/autopep8/)

## 2. Commit

- [Install lint-fix library and update dependencies](https://github.com/hayat01sh1da/github-wiki-organisers/commit/25a46a02bd7c428f6ab231e02c7e87a9c5973e87)
- [Execute lint fixed with autopep8](https://github.com/hayat01sh1da/github-wiki-organisers/commit/14bf411bf9bb5f440931fbe2ac0b0c815db1af2b)
- [ove module imports to the top of the file in order to comply with PEP 8 guidelines](https://github.com/hayat01sh1da/github-wiki-organisers/pull/59/changes/dcb27f8651efe2129e0d3e7affcd238e5a435130)