### PR TITLE
[python] Migrate from Native Python UnitTest to pytest

### DIFF
--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -1,0 +1,64 @@
+import glob
+import os
+import shutil
+import sys
+
+sys.path.append('./src')
+
+
+import pytest
+
+
+_DEFAULT_FILE_MAPS = {
+    ('Owner', 'English'): {
+        'Owned Wiki.md': 'Owner: @test-owner',
+        'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
+        'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
+        'Unowned Wiki 1.md': '',
+        'Unowned Wiki 2.md': 'This is a sample Wiki',
+    },
+    ('Owner', 'Japanese'): {
+        'Owner記名ありページ.md': 'Owner: @test-owner',
+        'Ownerチームが不明だが必要なページ.md': 'Owner: Ownerチームが不明だが必要なページ群',
+        'Ownerチーム・要or不要が不明なページ.md': 'Owner: Ownerチーム・要or不要が不明なページ群',
+        'Owner記名なしページ1.md': '',
+        'Owner記名なしページ2.md': 'サンプル Wiki',
+    },
+    ('Category', 'English'): {
+        'Categorised Wiki.md': 'Category: test-category',
+        'Uncategorised Wiki 1.md': '',
+        'Uncategorised Wiki 2.md': 'This is a sample Wiki',
+    },
+    ('Category', 'Japanese'): {
+        'Category記載ありページ.md': 'Category: test-category',
+        'Category記載なしページ1.md': '',
+        'Category記載なしページ2.md': 'サンプル Wiki',
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_pycaches():
+    before = set(glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True))
+    yield
+    for pycache in before:
+        if os.path.exists(pycache):
+            shutil.rmtree(pycache)
+
+
+@pytest.fixture
+def wiki_workspace():
+    base_path = os.path.join('.', 'test', 'wiki')
+
+    def _build(group_by='Owner', language='English', file_maps=None):
+        if file_maps is None:
+            file_maps = _DEFAULT_FILE_MAPS[(group_by, language)]
+        os.makedirs(base_path, exist_ok=True)
+        for wiki, namespace in file_maps.items():
+            with open(os.path.join(base_path, wiki), 'w') as f:
+                f.write(namespace)
+        return base_path
+
+    yield _build
+    if os.path.exists(base_path):
+        shutil.rmtree(base_path)

--- a/python/test/test_application.py
+++ b/python/test/test_application.py
@@ -1,119 +1,27 @@
-import sys
-import unittest
-import os
-import glob
-import shutil
-sys.path.append('./src')
+import pytest
+
 from application import Application
 
 
-class TestApplication(unittest.TestCase):
-    def setUp(
-            self,
-            base_path=os.path.join(
-                '.',
-                'test',
-                'wiki'),
-            group_by='Owner',
-            language='English',
-            home_overflow=False):
-        self.base_path = base_path
-        self.group_by = group_by
-        self.language = language
-        self.home_overflow = home_overflow
-        self.pycaches = glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True)
-        os.makedirs(self.base_path, exist_ok=True)
-        for wiki, namespace in self.__test_file_maps__().items():
-            with open(os.path.join(self.base_path, wiki), 'w') as f:
-                f.write(namespace)
-
-    def tearDown(self):
-        if os.path.exists(self.base_path):
-            shutil.rmtree(self.base_path)
-        for pycache in self.pycaches:
-            if os.path.exists(pycache):
-                shutil.rmtree(pycache)
-
-    def test_validate_group_by(self):
-        with self.assertRaises(ValueError) as cm:
-            Application(
-                base_path=self.base_path,
-                group_by='Group',
-                language=self.language,
-                home_overflow=self.home_overflow)
-        self.assertEqual(str(cm.exception), 'Invalid group_by: `Group`')
-
-    def test_validate_language(self):
-        with self.assertRaises(ValueError) as cm:
-            Application(
-                base_path=self.base_path,
-                group_by=self.group_by,
-                language='Spanish',
-                home_overflow=self.home_overflow)
-        self.assertEqual(str(cm.exception), 'Invalid language: `Spanish`')
-
-    def test_validate_home_overflow(self):
-        with self.assertRaises(ValueError) as cm:
-            Application(
-                base_path=self.base_path,
-                group_by=self.group_by,
-                language=self.language,
-                home_overflow='foo')
-        self.assertEqual(str(cm.exception),
-                         'Invalid home_overflow: `foo` must be boolean')
-
-    def test_run(self):
-        with self.assertRaises(NotImplementedError) as cm:
-            Application(
-                base_path=self.base_path,
-                group_by=self.group_by,
-                language=self.language,
-                home_overflow=self.home_overflow,
-            ).run()
-        self.assertEqual(
-            'This method must be implemented in each subclass.', str(
-                cm.exception))
-
-    # private
-
-    def __test_file_maps__(self):
-        match self.group_by:
-            case 'Owner':
-                match self.language:
-                    case 'English':
-                        return {
-                            'Owned Wiki.md': 'Owner: @test-owner',
-                            'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
-                            'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
-                            'Unowned Wiki 1.md': '',
-                            'Unowned Wiki 2.md': 'This is a sample Wiki'}
-                    case 'Japanese':
-                        return {
-                            'Owner記名ありページ.md': 'Owner: @test-owner',
-                            'Ownerチームが不明だが必要なページ.md': 'Owner: Ownerチームが不明だが必要なページ群',
-                            'Ownerチーム・要or不要が不明なページ.md': 'Owner: Ownerチーム・要or不要が不明なページ群',
-                            'Owner記名なしページ1.md': '',
-                            'Owner記名なしページ2.md': 'サンプル Wiki'}
-            case 'Category':
-                match self.language:
-                    case 'English':
-                        return {
-                            'Categorised Wiki.md': 'Category: test-category',
-                            'Uncategorised Wiki 1.md': '',
-                            'Uncategorised Wiki 2.md': 'This is a sample Wiki',
-                        }
-                    case 'Japanese':
-                        return {
-                            'Category記載ありページ.md': 'Category: test-category',
-                            'Category記載なしページ1.md': '',
-                            'Category記載なしページ2.md': 'サンプル Wiki'
-                        }
+def test_validate_group_by(wiki_workspace):
+    base_path = wiki_workspace()
+    with pytest.raises(ValueError, match=r'^Invalid group_by: `Group`$'):
+        Application(base_path=base_path, group_by='Group', language='English', home_overflow=False)
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_validate_language(wiki_workspace):
+    base_path = wiki_workspace()
+    with pytest.raises(ValueError, match=r'^Invalid language: `Spanish`$'):
+        Application(base_path=base_path, group_by='Owner', language='Spanish', home_overflow=False)
+
+
+def test_validate_home_overflow(wiki_workspace):
+    base_path = wiki_workspace()
+    with pytest.raises(ValueError, match=r'^Invalid home_overflow: `foo` must be boolean$'):
+        Application(base_path=base_path, group_by='Owner', language='English', home_overflow='foo')
+
+
+def test_run_raises_not_implemented(wiki_workspace):
+    base_path = wiki_workspace()
+    with pytest.raises(NotImplementedError, match=r'^This method must be implemented in each subclass\.$'):
+        Application(base_path=base_path, group_by='Owner', language='English', home_overflow=False).run()

--- a/python/test/test_home.py
+++ b/python/test/test_home.py
@@ -1,237 +1,172 @@
-from home import Home
-import sys
-import os
 import glob
-import unittest
-sys.path.append('./src')
-sys.path.append('./test')
-from test_application import TestApplication
+import os
+
+from home import Home
 
 
-class TestHome(TestApplication):
-    def setUp(self, group_by='Owner', language='English', home_overflow=False):
-        super().setUp(group_by=group_by, language=language, home_overflow=home_overflow)
-        Home(
-            base_path=self.base_path,
-            group_by=group_by,
-            language=language,
-            home_overflow=home_overflow).run()
-        path_to_home = os.path.join(self.base_path, 'Home.md')
-        with open(path_to_home) as f:
-            self.home = f.read()
-        self.path_to_wikis_by_owner = os.path.join(
-            self.base_path, 'wikis-by-owner')
-        self.overflow_files = sorted(
-            glob.glob(
-                os.path.join(
-                    self.path_to_wikis_by_owner,
-                    '*.md')))
-
-    def __expected_wikis_by_owner__(self, namespaces):
-        return sorted([os.path.join(self.path_to_wikis_by_owner,
-                      f'{namespace}.md') for namespace in namespaces])
+def _run_home(wiki_workspace, group_by='Owner', language='English', home_overflow=False):
+    base_path = wiki_workspace(group_by=group_by, language=language)
+    Home(base_path=base_path, group_by=group_by, language=language, home_overflow=home_overflow).run()
+    with open(os.path.join(base_path, 'Home.md')) as f:
+        home = f.read()
+    path_to_wikis_by_owner = os.path.join(base_path, 'wikis-by-owner')
+    overflow_files = sorted(glob.glob(os.path.join(path_to_wikis_by_owner, '*.md')))
+    return home, path_to_wikis_by_owner, overflow_files
 
 
-class EnglishOwnedHomeWithoutOverflowTest(TestHome):
-    def test_run(self):
-        self.assertFalse(os.path.exists(self.path_to_wikis_by_owner))
-        self.assertEqual(self.home, self.__home_passage__())
-
-    # private
-
-    def __home_passage__(self):
-        passage = '## How to Manage Wiki Pages\n'
-        passage += '\n'
-        passage += 'This Home page manage wikis by owner group.\n'
-        passage += '\n'
-        passage += 'Absence of ownership declaration worsens maintainability and searchability because it makes ambiguous which team the responsibility belongs to.  \n'
-        passage += 'Kindly make sure to articulate `Owner: @OWNER_TEAM` of the top of each of your wiki page to avoid it.\n'
-        passage += '\n'
-        passage += 'Also, please keep in mind that you do not have to edit Home and Sidebar by yourself, which are automatically updated by a GitHub Actions cron job.\n'
-        passage += '\n'
-        passage += '## [@test-owner](https://github.com/orgs/hayat01sh1da/teams/test-owner)\n'
-        passage += '\n'
-        passage += '- [[Owned Wiki]]\n'
-        passage += '\n'
-        passage += '## Unknown Owner nor Necessity\n'
-        passage += '\n'
-        passage += '- [[Unknown Owner nor Necessity Wiki]]\n'
-        passage += '\n'
-        passage += '## Unowned but Necessary\n'
-        passage += '\n'
-        passage += '- [[Unowned but Necessary Wiki]]\n'
-        passage += '\n'
-        passage += '## Unowned\n'
-        passage += '\n'
-        passage += '- [[Unowned Wiki 1]]\n'
-        passage += '- [[Unowned Wiki 2]]\n'
-
-        return passage
+def _expected_wikis_by_owner(path_to_wikis_by_owner, namespaces):
+    return sorted(os.path.join(path_to_wikis_by_owner, f'{namespace}.md') for namespace in namespaces)
 
 
-class EnglishOwnedHomeWithOverflowTest(TestHome):
-    def setUp(self):
-        super().setUp(home_overflow=True)
-
-    def test_run(self):
-        self.assertTrue(os.path.exists(self.path_to_wikis_by_owner))
-        self.assertEqual(self.home, self.__home_passage__())
-        expected_files = self.__expected_wikis_by_owner__(
-            ['@test-owner', 'Unknown Owner nor Necessity', 'Unowned but Necessary', 'Unowned'])
-        self.assertEqual(self.overflow_files, expected_files)
-
-    # private
-
-    def __home_passage__(self):
-        passage = '## How to Manage Wiki Pages\n'
-        passage += '\n'
-        passage += 'This Home page manage wikis by owner group.\n'
-        passage += '\n'
-        passage += 'Absence of ownership declaration worsens maintainability and searchability because it makes ambiguous which team the responsibility belongs to.  \n'
-        passage += 'Kindly make sure to articulate `Owner: @OWNER_TEAM` of the top of each of your wiki page to avoid it.\n'
-        passage += '\n'
-        passage += 'Also, please keep in mind that you do not have to edit Home and Sidebar by yourself, which are automatically updated by a GitHub Actions cron job.\n'
-        passage += '\n'
-        passage += '- [[@test-owner]]\n'
-        passage += '- [[Unknown Owner nor Necessity]]\n'
-        passage += '- [[Unowned but Necessary]]\n'
-        passage += '- [[Unowned]]\n'
-
-        return passage
-
-
-class EnglishCategorisedHomeTest(TestHome):
-    def setUp(self):
-        super().setUp(group_by='Category')
-
-    def test_run(self):
-        self.assertEqual(self.home, self.__home_passage__())
-
-    # private
-
-    def __home_passage__(self):
-        passage = '## How to Manage Wiki Pages\n'
-        passage += '\n'
-        passage += 'This Home page manage wikis by category group.\n'
-        passage += '\n'
-        passage += 'Absence of category declaration worsens maintainability and searchability.  \n'
-        passage += 'Kindly make sure to articulate `Category: CATEGORY_NAME` of the top of each of your wiki page to avoid it.\n'
-        passage += '\n'
-        passage += 'Also, please keep in mind that you do not have to edit Home and Sidebar by yourself, which are automatically updated by a GitHub Actions cron job.\n'
-        passage += '\n'
-        passage += '## test-category\n'
-        passage += '\n'
-        passage += '- [[Categorised Wiki]]\n'
-        passage += '\n'
-        passage += '## Uncategorised\n'
-        passage += '\n'
-        passage += '- [[Uncategorised Wiki 1]]\n'
-        passage += '- [[Uncategorised Wiki 2]]\n'
-
-        return passage
-
-
-class JapaneseOwnedHomeWithoutOverflowTest(TestHome):
-    def setUp(self):
-        super().setUp(language='Japanese')
-
-    def test_run(self):
-        self.assertFalse(os.path.exists(self.path_to_wikis_by_owner))
-        self.assertEqual(self.home, self.__home_passage__())
-
-    # private
-
-    def __home_passage__(self):
-        passage = '## Wiki ページの運用ルール\n'
-        passage += '\n'
-        passage += 'このページは Owner チームごとに Wiki をグルーピングして一覧化しています。\n'
-        passage += '\n'
-        passage += 'Ownership をどのチームが持つのかが不明だと、責任の所在が不明瞭になり、保守性の悪化に伴うノイズの増加と検索性の悪化が発生します。  \n'
-        passage += '治安維持のため、各ページの冒頭に `Owner: @オーナーチーム` を明記して頂きますようよろしくお願いします。\n'
-        passage += '\n'
-        passage += 'なお、Home・Sidebar は専用の定期実行ジョブで自動更新しますので編集は不要です。\n'
-        passage += '\n'
-        passage += '## [@test-owner](https://github.com/orgs/hayat01sh1da/teams/test-owner)\n'
-        passage += '\n'
-        passage += '- [[Owner記名ありページ]]\n'
-        passage += '\n'
-        passage += '## Ownerチームが不明だが必要なページ群\n'
-        passage += '\n'
-        passage += '- [[Ownerチームが不明だが必要なページ]]\n'
-        passage += '\n'
-        passage += '## Ownerチーム・要or不要が不明なページ群\n'
-        passage += '\n'
-        passage += '- [[Ownerチーム・要or不要が不明なページ]]\n'
-        passage += '\n'
-        passage += '## Owner記名なし\n'
-        passage += '\n'
-        passage += '- [[Owner記名なしページ1]]\n'
-        passage += '- [[Owner記名なしページ2]]\n'
-
-        return passage
-
-
-class JapaneseOwnedHomeWihOverflowTest(TestHome):
-    def setUp(self):
-        super().setUp(language='Japanese', home_overflow=True)
-
-    def test_run(self):
-        self.assertTrue(os.path.exists(self.path_to_wikis_by_owner))
-        self.assertEqual(self.home, self.__home_passage__())
-        expected_files = self.__expected_wikis_by_owner__(
-            ['@test-owner', 'Ownerチームが不明だが必要なページ群', 'Ownerチーム・要or不要が不明なページ群', 'Owner記名なし'])
-        self.assertEqual(self.overflow_files, expected_files)
-
-    # private
-
-    def __home_passage__(self):
-        passage = '## Wiki ページの運用ルール\n'
-        passage += '\n'
-        passage += 'このページは Owner チームごとに Wiki をグルーピングして一覧化しています。\n'
-        passage += '\n'
-        passage += 'Ownership をどのチームが持つのかが不明だと、責任の所在が不明瞭になり、保守性の悪化に伴うノイズの増加と検索性の悪化が発生します。  \n'
-        passage += '治安維持のため、各ページの冒頭に `Owner: @オーナーチーム` を明記して頂きますようよろしくお願いします。\n'
-        passage += '\n'
-        passage += 'なお、Home・Sidebar は専用の定期実行ジョブで自動更新しますので編集は不要です。\n'
-        passage += '\n'
-        passage += '- [[@test-owner]]\n'
-        passage += '- [[Ownerチームが不明だが必要なページ群]]\n'
-        passage += '- [[Ownerチーム・要or不要が不明なページ群]]\n'
-        passage += '- [[Owner記名なし]]\n'
-
-        return passage
+_ENGLISH_OWNED_HOME = (
+    '## How to Manage Wiki Pages\n'
+    '\n'
+    'This Home page manage wikis by owner group.\n'
+    '\n'
+    'Absence of ownership declaration worsens maintainability and searchability because it makes ambiguous which team the responsibility belongs to.  \n'
+    'Kindly make sure to articulate `Owner: @OWNER_TEAM` of the top of each of your wiki page to avoid it.\n'
+    '\n'
+    'Also, please keep in mind that you do not have to edit Home and Sidebar by yourself, which are automatically updated by a GitHub Actions cron job.\n'
+    '\n'
+)
+_ENGLISH_OWNED_HOME_WITHOUT_OVERFLOW = _ENGLISH_OWNED_HOME + (
+    '## [@test-owner](https://github.com/orgs/hayat01sh1da/teams/test-owner)\n'
+    '\n'
+    '- [[Owned Wiki]]\n'
+    '\n'
+    '## Unknown Owner nor Necessity\n'
+    '\n'
+    '- [[Unknown Owner nor Necessity Wiki]]\n'
+    '\n'
+    '## Unowned but Necessary\n'
+    '\n'
+    '- [[Unowned but Necessary Wiki]]\n'
+    '\n'
+    '## Unowned\n'
+    '\n'
+    '- [[Unowned Wiki 1]]\n'
+    '- [[Unowned Wiki 2]]\n'
+)
+_ENGLISH_OWNED_HOME_WITH_OVERFLOW = _ENGLISH_OWNED_HOME + (
+    '- [[@test-owner]]\n'
+    '- [[Unknown Owner nor Necessity]]\n'
+    '- [[Unowned but Necessary]]\n'
+    '- [[Unowned]]\n'
+)
+_ENGLISH_CATEGORISED_HOME = (
+    '## How to Manage Wiki Pages\n'
+    '\n'
+    'This Home page manage wikis by category group.\n'
+    '\n'
+    'Absence of category declaration worsens maintainability and searchability.  \n'
+    'Kindly make sure to articulate `Category: CATEGORY_NAME` of the top of each of your wiki page to avoid it.\n'
+    '\n'
+    'Also, please keep in mind that you do not have to edit Home and Sidebar by yourself, which are automatically updated by a GitHub Actions cron job.\n'
+    '\n'
+    '## test-category\n'
+    '\n'
+    '- [[Categorised Wiki]]\n'
+    '\n'
+    '## Uncategorised\n'
+    '\n'
+    '- [[Uncategorised Wiki 1]]\n'
+    '- [[Uncategorised Wiki 2]]\n'
+)
+_JAPANESE_OWNED_HOME = (
+    '## Wiki ページの運用ルール\n'
+    '\n'
+    'このページは Owner チームごとに Wiki をグルーピングして一覧化しています。\n'
+    '\n'
+    'Ownership をどのチームが持つのかが不明だと、責任の所在が不明瞭になり、保守性の悪化に伴うノイズの増加と検索性の悪化が発生します。  \n'
+    '治安維持のため、各ページの冒頭に `Owner: @オーナーチーム` を明記して頂きますようよろしくお願いします。\n'
+    '\n'
+    'なお、Home・Sidebar は専用の定期実行ジョブで自動更新しますので編集は不要です。\n'
+    '\n'
+)
+_JAPANESE_OWNED_HOME_WITHOUT_OVERFLOW = _JAPANESE_OWNED_HOME + (
+    '## [@test-owner](https://github.com/orgs/hayat01sh1da/teams/test-owner)\n'
+    '\n'
+    '- [[Owner記名ありページ]]\n'
+    '\n'
+    '## Ownerチームが不明だが必要なページ群\n'
+    '\n'
+    '- [[Ownerチームが不明だが必要なページ]]\n'
+    '\n'
+    '## Ownerチーム・要or不要が不明なページ群\n'
+    '\n'
+    '- [[Ownerチーム・要or不要が不明なページ]]\n'
+    '\n'
+    '## Owner記名なし\n'
+    '\n'
+    '- [[Owner記名なしページ1]]\n'
+    '- [[Owner記名なしページ2]]\n'
+)
+_JAPANESE_OWNED_HOME_WITH_OVERFLOW = _JAPANESE_OWNED_HOME + (
+    '- [[@test-owner]]\n'
+    '- [[Ownerチームが不明だが必要なページ群]]\n'
+    '- [[Ownerチーム・要or不要が不明なページ群]]\n'
+    '- [[Owner記名なし]]\n'
+)
+_JAPANESE_CATEGORISED_HOME = (
+    '## Wiki ページの運用ルール\n'
+    '\n'
+    'このページは Category ごとに Wiki をグルーピングして一覧化しています。\n'
+    '\n'
+    'Category が不明だと、保守性と検索性の悪化が発生します。  \n'
+    '治安維持のため、各ページの冒頭に `Category: カテゴリー名` を明記して頂きますようよろしくお願いします。\n'
+    '\n'
+    'なお、Home・Sidebar は専用の定期実行ジョブで自動更新しますので編集は不要です。\n'
+    '\n'
+    '## test-category\n'
+    '\n'
+    '- [[Category記載ありページ]]\n'
+    '\n'
+    '## Category記載なし\n'
+    '\n'
+    '- [[Category記載なしページ1]]\n'
+    '- [[Category記載なしページ2]]\n'
+)
 
 
-class JapaneseCategorisedHomeTest(TestHome):
-    def setUp(self):
-        super().setUp(group_by='Category', language='Japanese')
-
-    def test_run(self):
-        self.assertEqual(self.home, self.__home_passage__())
-
-    # private
-
-    def __home_passage__(self):
-        passage = '## Wiki ページの運用ルール\n'
-        passage += '\n'
-        passage += 'このページは Category ごとに Wiki をグルーピングして一覧化しています。\n'
-        passage += '\n'
-        passage += 'Category が不明だと、保守性と検索性の悪化が発生します。  \n'
-        passage += '治安維持のため、各ページの冒頭に `Category: カテゴリー名` を明記して頂きますようよろしくお願いします。\n'
-        passage += '\n'
-        passage += 'なお、Home・Sidebar は専用の定期実行ジョブで自動更新しますので編集は不要です。\n'
-        passage += '\n'
-        passage += '## test-category\n'
-        passage += '\n'
-        passage += '- [[Category記載ありページ]]\n'
-        passage += '\n'
-        passage += '## Category記載なし\n'
-        passage += '\n'
-        passage += '- [[Category記載なしページ1]]\n'
-        passage += '- [[Category記載なしページ2]]\n'
-
-        return passage
+def test_english_owned_home_without_overflow(wiki_workspace):
+    home, path_to_wikis_by_owner, _ = _run_home(wiki_workspace)
+    assert not os.path.exists(path_to_wikis_by_owner)
+    assert home == _ENGLISH_OWNED_HOME_WITHOUT_OVERFLOW
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_english_owned_home_with_overflow(wiki_workspace):
+    home, path_to_wikis_by_owner, overflow_files = _run_home(wiki_workspace, home_overflow=True)
+    assert os.path.exists(path_to_wikis_by_owner)
+    assert home == _ENGLISH_OWNED_HOME_WITH_OVERFLOW
+    assert overflow_files == _expected_wikis_by_owner(
+        path_to_wikis_by_owner,
+        ['@test-owner', 'Unknown Owner nor Necessity', 'Unowned but Necessary', 'Unowned'],
+    )
+
+
+def test_english_categorised_home(wiki_workspace):
+    home, _, _ = _run_home(wiki_workspace, group_by='Category')
+    assert home == _ENGLISH_CATEGORISED_HOME
+
+
+def test_japanese_owned_home_without_overflow(wiki_workspace):
+    home, path_to_wikis_by_owner, _ = _run_home(wiki_workspace, language='Japanese')
+    assert not os.path.exists(path_to_wikis_by_owner)
+    assert home == _JAPANESE_OWNED_HOME_WITHOUT_OVERFLOW
+
+
+def test_japanese_owned_home_with_overflow(wiki_workspace):
+    home, path_to_wikis_by_owner, overflow_files = _run_home(
+        wiki_workspace, language='Japanese', home_overflow=True,
+    )
+    assert os.path.exists(path_to_wikis_by_owner)
+    assert home == _JAPANESE_OWNED_HOME_WITH_OVERFLOW
+    assert overflow_files == _expected_wikis_by_owner(
+        path_to_wikis_by_owner,
+        ['@test-owner', 'Ownerチームが不明だが必要なページ群', 'Ownerチーム・要or不要が不明なページ群', 'Owner記名なし'],
+    )
+
+
+def test_japanese_categorised_home(wiki_workspace):
+    home, _, _ = _run_home(wiki_workspace, group_by='Category', language='Japanese')
+    assert home == _JAPANESE_CATEGORISED_HOME

--- a/python/test/test_sidebar.py
+++ b/python/test/test_sidebar.py
@@ -1,101 +1,64 @@
-from sidebar import Sidebar
-import sys
 import os
-import unittest
-sys.path.append('./src')
-sys.path.append('./test')
-from test_application import TestApplication
+
+from sidebar import Sidebar
 
 
-class TestSidebar(TestApplication):
-    def setUp(self, group_by='Owner', language='English'):
-        super().setUp(group_by=group_by, language=language)
-        Sidebar(self.base_path, group_by=group_by, language=language).run()
-        path_to_sidebar = os.path.join(self.base_path, '_Sidebar.md')
-        with open(path_to_sidebar) as f:
-            self.sidebar = f.read()
+def _run_sidebar(wiki_workspace, group_by='Owner', language='English'):
+    base_path = wiki_workspace(group_by=group_by, language=language)
+    Sidebar(base_path, group_by=group_by, language=language).run()
+    with open(os.path.join(base_path, '_Sidebar.md')) as f:
+        return f.read()
 
 
-class EnglishOwnedSidebarTest(TestSidebar):
-    def test_run(self):
-        self.assertEqual(self.sidebar, self.__wiki_list__())
-
-    # private
-
-    def __wiki_list__(self):
-        lst = '- [@test-owner](https://github.com/orgs/hayat01sh1da/teams/test-owner)\n'
-        lst += '  - [[Owned Wiki]]\n'
-        lst += '- Unknown Owner nor Necessity\n'
-        lst += '  - [[Unknown Owner nor Necessity Wiki]]\n'
-        lst += '- Unowned but Necessary\n'
-        lst += '  - [[Unowned but Necessary Wiki]]\n'
-        lst += '- Unowned\n'
-        lst += '  - [[Unowned Wiki 1]]\n'
-        lst += '  - [[Unowned Wiki 2]]\n'
-
-        return lst
-
-
-class EnglishPlainSidebarTest(TestSidebar):
-    def setUp(self):
-        super().setUp(group_by='Category')
-
-    def test_run(self):
-        self.assertEqual(self.sidebar, self.__wiki_list__())
-
-    # private
-
-    def __wiki_list__(self):
-        lst = '- test-category\n'
-        lst += '  - [[Categorised Wiki]]\n'
-        lst += '- Uncategorised\n'
-        lst += '  - [[Uncategorised Wiki 1]]\n'
-        lst += '  - [[Uncategorised Wiki 2]]\n'
-
-        return lst
-
-
-class JapaneseOwnedSidebarTest(TestSidebar):
-    def setUp(self):
-        super().setUp(language='Japanese')
-
-    def test_run(self):
-        self.assertEqual(self.sidebar, self.__wiki_list__())
-
-    # private
-
-    def __wiki_list__(self):
-        lst = '- [@test-owner](https://github.com/orgs/hayat01sh1da/teams/test-owner)\n'
-        lst += '  - [[Owner記名ありページ]]\n'
-        lst += '- Ownerチームが不明だが必要なページ群\n'
-        lst += '  - [[Ownerチームが不明だが必要なページ]]\n'
-        lst += '- Ownerチーム・要or不要が不明なページ群\n'
-        lst += '  - [[Ownerチーム・要or不要が不明なページ]]\n'
-        lst += '- Owner記名なし\n'
-        lst += '  - [[Owner記名なしページ1]]\n'
-        lst += '  - [[Owner記名なしページ2]]\n'
-
-        return lst
+_ENGLISH_OWNED = (
+    '- [@test-owner](https://github.com/orgs/hayat01sh1da/teams/test-owner)\n'
+    '  - [[Owned Wiki]]\n'
+    '- Unknown Owner nor Necessity\n'
+    '  - [[Unknown Owner nor Necessity Wiki]]\n'
+    '- Unowned but Necessary\n'
+    '  - [[Unowned but Necessary Wiki]]\n'
+    '- Unowned\n'
+    '  - [[Unowned Wiki 1]]\n'
+    '  - [[Unowned Wiki 2]]\n'
+)
+_ENGLISH_PLAIN = (
+    '- test-category\n'
+    '  - [[Categorised Wiki]]\n'
+    '- Uncategorised\n'
+    '  - [[Uncategorised Wiki 1]]\n'
+    '  - [[Uncategorised Wiki 2]]\n'
+)
+_JAPANESE_OWNED = (
+    '- [@test-owner](https://github.com/orgs/hayat01sh1da/teams/test-owner)\n'
+    '  - [[Owner記名ありページ]]\n'
+    '- Ownerチームが不明だが必要なページ群\n'
+    '  - [[Ownerチームが不明だが必要なページ]]\n'
+    '- Ownerチーム・要or不要が不明なページ群\n'
+    '  - [[Ownerチーム・要or不要が不明なページ]]\n'
+    '- Owner記名なし\n'
+    '  - [[Owner記名なしページ1]]\n'
+    '  - [[Owner記名なしページ2]]\n'
+)
+_JAPANESE_PLAIN = (
+    '- test-category\n'
+    '  - [[Category記載ありページ]]\n'
+    '- Category記載なし\n'
+    '  - [[Category記載なしページ1]]\n'
+    '  - [[Category記載なしページ2]]\n'
+)
 
 
-class JapanesePlainSidebarTest(TestSidebar):
-    def setUp(self):
-        super().setUp(group_by='Category', language='Japanese')
-
-    def test_run(self):
-        self.assertEqual(self.sidebar, self.__wiki_list__())
-
-    # private
-
-    def __wiki_list__(self):
-        lst = '- test-category\n'
-        lst += '  - [[Category記載ありページ]]\n'
-        lst += '- Category記載なし\n'
-        lst += '  - [[Category記載なしページ1]]\n'
-        lst += '  - [[Category記載なしページ2]]\n'
-
-        return lst
+def test_english_owned_sidebar(wiki_workspace):
+    assert _run_sidebar(wiki_workspace) == _ENGLISH_OWNED
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_english_plain_sidebar(wiki_workspace):
+    assert _run_sidebar(wiki_workspace, group_by='Category') == _ENGLISH_PLAIN
+
+
+def test_japanese_owned_sidebar(wiki_workspace):
+    assert _run_sidebar(wiki_workspace, language='Japanese') == _JAPANESE_OWNED
+
+
+def test_japanese_plain_sidebar(wiki_workspace):
+    assert _run_sidebar(wiki_workspace, group_by='Category', language='Japanese') == _JAPANESE_PLAIN

--- a/python/test/test_unknown_wiki_count_list_exporter.py
+++ b/python/test/test_unknown_wiki_count_list_exporter.py
@@ -1,326 +1,148 @@
-from unknown_wiki_count_list_exporter import UnknownWikiCountListExporter
-import sys
 import os
-import unittest
-sys.path.append('./src')
-sys.path.append('./test')
-from test_application import TestApplication
 
-
-class TestUnknownWikiCountListExporter(TestApplication):
-    def setUp(self, group_by='Owner', language='English'):
-        super().setUp(group_by=group_by, language=language)
-        UnknownWikiCountListExporter(
-            self.base_path,
-            group_by=group_by,
-            language=language).run()
-        path_to_unknown_wiki_count_list = os.path.join(
-            self.base_path, 'unknown_wiki_count_list_by_namespace.txt')
-        with open(path_to_unknown_wiki_count_list) as f:
-            self.unknown_wiki_count_list = f.read()
-
-
-class EnglishOwnerTestRegularCase1(TestUnknownWikiCountListExporter):
-    def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list,
-                         self.__unknown_wiki_count_list_by_namespace__())
-
-    # private
-
-    def __unknown_wiki_count_list_by_namespace__(self):
-        lst = 'Unknown Owner nor Necessity: 1\n'
-        lst += 'Unowned but Necessary: 1\n'
-        lst += 'Unowned: 2\n'
-
-        return lst
-
-
-class EnglishOwnerTestRegularCase2(TestUnknownWikiCountListExporter):
-    def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list,
-                         self.__unknown_wiki_count_list_by_namespace__())
-
-    # private
-
-    def __unknown_wiki_count_list_by_namespace__(self):
-        lst = 'Unknown Owner nor Necessity: 1\n'
-        lst += 'Unowned but Necessary: 1\n'
-        lst += 'Unowned: 2\n'
-
-        return lst
-
-    def __test_file_maps__(self):
-        return {
-            'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
-            'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
-            'Unowned Wiki 1.md': '',
-            'Unowned Wiki 2.md': 'This is a sample Wiki'}
-
-
-class EnglishOwnerTestIrregularCase1(TestUnknownWikiCountListExporter):
-    def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list,
-                         self.__unknown_wiki_count_list_by_namespace__())
-
-    # private
-
-    def __unknown_wiki_count_list_by_namespace__(self):
-        lst = 'Unknown Owner nor Necessity: 0\n'
-        lst += 'Unowned but Necessary: 1\n'
-        lst += 'Unowned: 2\n'
-
-        return lst
-
-    def __test_file_maps__(self):
-        return {
-            'Owned Wiki.md': 'Owner: @test-owner',
-            'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
-            'Unowned Wiki 1.md': '',
-            'Unowned Wiki 2.md': 'This is a sample Wiki'
-        }
-
-
-class EnglishOwnerTestIrregularCase2(TestUnknownWikiCountListExporter):
-    def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list,
-                         self.__unknown_wiki_count_list_by_namespace__())
-
-    # private
-
-    def __unknown_wiki_count_list_by_namespace__(self):
-        lst = 'Unknown Owner nor Necessity: 1\n'
-        lst += 'Unowned but Necessary: 0\n'
-        lst += 'Unowned: 2\n'
-
-        return lst
-
-    def __test_file_maps__(self):
-        return {
-            'Owned Wiki.md': 'Owner: @test-owner',
-            'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
-            'Unowned Wiki 1.md': '',
-            'Unowned Wiki 2.md': 'This is a sample Wiki'}
-
-
-class EnglishOwnerTestIrregularCase3(TestUnknownWikiCountListExporter):
-    def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list,
-                         self.__unknown_wiki_count_list_by_namespace__())
-
-    # private
-
-    def __unknown_wiki_count_list_by_namespace__(self):
-        lst = 'Unknown Owner nor Necessity: 1\n'
-        lst += 'Unowned but Necessary: 1\n'
-        lst += 'Unowned: 0\n'
-
-        return lst
-
-    def __test_file_maps__(self):
-        return {
-            'Owned Wiki.md': 'Owner: @test-owner',
-            'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
-            'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
-        }
-
-
-class EnglishCategoryTestRegularCase(TestUnknownWikiCountListExporter):
-    def setUp(self):
-        super().setUp(group_by='Category')
-
-    def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list,
-                         self.__unknown_wiki_count_list_by_namespace__())
-
-    # private
-
-    def __unknown_wiki_count_list_by_namespace__(self):
-        return 'Uncategorised: 2\n'
-
-
-class EnglishCategoryTestIrregularCase(TestUnknownWikiCountListExporter):
-    def setUp(self):
-        super().setUp(group_by='Category')
-
-    def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list,
-                         self.__unknown_wiki_count_list_by_namespace__())
-
-    # private
-
-    def __unknown_wiki_count_list_by_namespace__(self):
-        lst = 'Uncategorised: 5\n'
-
-        return lst
-
-    def __test_file_maps__(self):
-        return {
-            'Owned Wiki.md': 'Owner: @test-owner',
-            'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
-            'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
-            'Unowned Wiki 1.md': '',
-            'Unowned Wiki 2.md': 'This is a sample Wiki'}
-
-
-class JapaneseOwnerTestRegularCase1(TestUnknownWikiCountListExporter):
-    def setUp(self):
-        super().setUp(language='Japanese')
-
-    def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list,
-                         self.__unknown_wiki_count_list_by_namespace__())
-
-    # private
-
-    def __unknown_wiki_count_list_by_namespace__(self):
-        lst = 'Ownerチームが不明だが必要なページ群: 1\n'
-        lst += 'Ownerチーム・要or不要が不明なページ群: 1\n'
-        lst += 'Owner記名なし: 2\n'
-
-        return lst
-
-
-class JapaneseOwnerTestRegularCase2(TestUnknownWikiCountListExporter):
-    def setUp(self):
-        super().setUp(language='Japanese')
-
-    def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list,
-                         self.__unknown_wiki_count_list_by_namespace__())
-
-    # private
-
-    def __unknown_wiki_count_list_by_namespace__(self):
-        lst = 'Ownerチームが不明だが必要なページ群: 1\n'
-        lst += 'Ownerチーム・要or不要が不明なページ群: 1\n'
-        lst += 'Owner記名なし: 2\n'
-
-        return lst
-
-    def __test_file_maps__(self):
-        return {
-            'Ownerチームが不明だが必要なページ.md': 'Owner: Ownerチームが不明だが必要なページ群',
-            'Ownerチーム・要or不要が不明なページ.md': 'Owner: Ownerチーム・要or不要が不明なページ群',
-            'Owner記名なしページ1.md': '',
-            'Owner記名なしページ2.md': 'サンプル Wiki'
-        }
-
-
-class JapaneseOwnerTestIrregularCase1(TestUnknownWikiCountListExporter):
-    def setUp(self):
-        super().setUp(language='Japanese')
-
-    def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list,
-                         self.__unknown_wiki_count_list_by_namespace__())
-
-    # private
-
-    def __unknown_wiki_count_list_by_namespace__(self):
-        lst = 'Ownerチームが不明だが必要なページ群: 1\n'
-        lst += 'Ownerチーム・要or不要が不明なページ群: 0\n'
-        lst += 'Owner記名なし: 2\n'
-
-        return lst
-
-    def __test_file_maps__(self):
-        return {
-            'Owner記名ありページ.md': 'Owner: @test-owner',
-            'Ownerチームが不明だが必要なページ.md': 'Owner: Ownerチームが不明だが必要なページ群',
-            'Owner記名なしページ1.md': '',
-            'Owner記名なしページ2.md': 'サンプル Wiki'
-        }
-
-
-class JapaneseOwnerTestIrregularCase2(TestUnknownWikiCountListExporter):
-    def setUp(self):
-        super().setUp(language='Japanese')
-
-    def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list,
-                         self.__unknown_wiki_count_list_by_namespace__())
-
-    # private
-
-    def __unknown_wiki_count_list_by_namespace__(self):
-        lst = 'Ownerチームが不明だが必要なページ群: 0\n'
-        lst += 'Ownerチーム・要or不要が不明なページ群: 1\n'
-        lst += 'Owner記名なし: 2\n'
-
-        return lst
-
-    def __test_file_maps__(self):
-        return {
-            'Owner記名ありページ.md': 'Owner: @test-owner',
-            'Ownerチーム・要or不要が不明なページ.md': 'Owner: Ownerチーム・要or不要が不明なページ群',
-            'Owner記名なしページ1.md': '',
-            'Owner記名なしページ2.md': 'サンプル Wiki'
-        }
-
-
-class JapaneseOwnerTestIrregularCase3(TestUnknownWikiCountListExporter):
-    def setUp(self):
-        super().setUp(language='Japanese')
-
-    def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list,
-                         self.__unknown_wiki_count_list_by_namespace__())
-
-    # private
-
-    def __unknown_wiki_count_list_by_namespace__(self):
-        lst = 'Ownerチームが不明だが必要なページ群: 1\n'
-        lst += 'Ownerチーム・要or不要が不明なページ群: 1\n'
-        lst += 'Owner記名なし: 0\n'
-
-        return lst
-
-    def __test_file_maps__(self):
-        return {
-            'Owner記名ありページ.md': 'Owner: @test-owner',
-            'Ownerチームが不明だが必要なページ.md': 'Owner: Ownerチームが不明だが必要なページ群',
-            'Ownerチーム・要or不要が不明なページ.md': 'Owner: Ownerチーム・要or不要が不明なページ群',
-        }
-
-
-class JapaneseCategoryTestRegularCase(TestUnknownWikiCountListExporter):
-    def setUp(self):
-        super().setUp(group_by='Category', language='Japanese')
-
-    def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list,
-                         self.__unknown_wiki_count_list_by_namespace__())
-
-    # private
-
-    def __unknown_wiki_count_list_by_namespace__(self):
-        return 'Category記載なし: 2\n'
-
-
-class JapaneseCategoryTestIrregularCase(TestUnknownWikiCountListExporter):
-    def setUp(self):
-        super().setUp(group_by='Category', language='Japanese')
-
-    def test_run(self):
-        self.assertEqual(self.unknown_wiki_count_list,
-                         self.__unknown_wiki_count_list_by_namespace__())
-
-    # private
-
-    def __unknown_wiki_count_list_by_namespace__(self):
-        lst = 'Category記載なし: 5\n'
-
-        return lst
-
-    def __test_file_maps__(self):
-        return {
-            'Owner記名ありページ.md': 'Owner: @test-owner',
-            'Ownerチームが不明だが必要なページ.md': 'Owner: Ownerチームが不明だが必要なページ群',
-            'Ownerチーム・要or不要が不明なページ.md': 'Owner: Ownerチーム・要or不要が不明なページ群',
-            'Owner記名なしページ1.md': '',
-            'Owner記名なしページ2.md': 'サンプル Wiki'
-        }
-
-
-if __name__ == '__main__':
-    unittest.main()
+import pytest
+
+from unknown_wiki_count_list_exporter import UnknownWikiCountListExporter
+
+
+def _run(wiki_workspace, group_by='Owner', language='English', file_maps=None):
+    base_path = wiki_workspace(group_by=group_by, language=language, file_maps=file_maps)
+    UnknownWikiCountListExporter(base_path, group_by=group_by, language=language).run()
+    with open(os.path.join(base_path, 'unknown_wiki_count_list_by_namespace.txt')) as f:
+        return f.read()
+
+
+@pytest.mark.parametrize(
+    ('file_maps', 'expected'),
+    [
+        (
+            None,
+            'Unknown Owner nor Necessity: 1\nUnowned but Necessary: 1\nUnowned: 2\n',
+        ),
+        (
+            {
+                'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
+                'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
+                'Unowned Wiki 1.md': '',
+                'Unowned Wiki 2.md': 'This is a sample Wiki',
+            },
+            'Unknown Owner nor Necessity: 1\nUnowned but Necessary: 1\nUnowned: 2\n',
+        ),
+        (
+            {
+                'Owned Wiki.md': 'Owner: @test-owner',
+                'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
+                'Unowned Wiki 1.md': '',
+                'Unowned Wiki 2.md': 'This is a sample Wiki',
+            },
+            'Unknown Owner nor Necessity: 0\nUnowned but Necessary: 1\nUnowned: 2\n',
+        ),
+        (
+            {
+                'Owned Wiki.md': 'Owner: @test-owner',
+                'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
+                'Unowned Wiki 1.md': '',
+                'Unowned Wiki 2.md': 'This is a sample Wiki',
+            },
+            'Unknown Owner nor Necessity: 1\nUnowned but Necessary: 0\nUnowned: 2\n',
+        ),
+        (
+            {
+                'Owned Wiki.md': 'Owner: @test-owner',
+                'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
+                'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
+            },
+            'Unknown Owner nor Necessity: 1\nUnowned but Necessary: 1\nUnowned: 0\n',
+        ),
+    ],
+)
+def test_english_owner(wiki_workspace, file_maps, expected):
+    assert _run(wiki_workspace, file_maps=file_maps) == expected
+
+
+@pytest.mark.parametrize(
+    ('file_maps', 'expected'),
+    [
+        (None, 'Uncategorised: 2\n'),
+        (
+            {
+                'Owned Wiki.md': 'Owner: @test-owner',
+                'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
+                'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
+                'Unowned Wiki 1.md': '',
+                'Unowned Wiki 2.md': 'This is a sample Wiki',
+            },
+            'Uncategorised: 5\n',
+        ),
+    ],
+)
+def test_english_category(wiki_workspace, file_maps, expected):
+    assert _run(wiki_workspace, group_by='Category', file_maps=file_maps) == expected
+
+
+@pytest.mark.parametrize(
+    ('file_maps', 'expected'),
+    [
+        (
+            None,
+            'Ownerチームが不明だが必要なページ群: 1\nOwnerチーム・要or不要が不明なページ群: 1\nOwner記名なし: 2\n',
+        ),
+        (
+            {
+                'Ownerチームが不明だが必要なページ.md': 'Owner: Ownerチームが不明だが必要なページ群',
+                'Ownerチーム・要or不要が不明なページ.md': 'Owner: Ownerチーム・要or不要が不明なページ群',
+                'Owner記名なしページ1.md': '',
+                'Owner記名なしページ2.md': 'サンプル Wiki',
+            },
+            'Ownerチームが不明だが必要なページ群: 1\nOwnerチーム・要or不要が不明なページ群: 1\nOwner記名なし: 2\n',
+        ),
+        (
+            {
+                'Owner記名ありページ.md': 'Owner: @test-owner',
+                'Ownerチームが不明だが必要なページ.md': 'Owner: Ownerチームが不明だが必要なページ群',
+                'Owner記名なしページ1.md': '',
+                'Owner記名なしページ2.md': 'サンプル Wiki',
+            },
+            'Ownerチームが不明だが必要なページ群: 1\nOwnerチーム・要or不要が不明なページ群: 0\nOwner記名なし: 2\n',
+        ),
+        (
+            {
+                'Owner記名ありページ.md': 'Owner: @test-owner',
+                'Ownerチーム・要or不要が不明なページ.md': 'Owner: Ownerチーム・要or不要が不明なページ群',
+                'Owner記名なしページ1.md': '',
+                'Owner記名なしページ2.md': 'サンプル Wiki',
+            },
+            'Ownerチームが不明だが必要なページ群: 0\nOwnerチーム・要or不要が不明なページ群: 1\nOwner記名なし: 2\n',
+        ),
+        (
+            {
+                'Owner記名ありページ.md': 'Owner: @test-owner',
+                'Ownerチームが不明だが必要なページ.md': 'Owner: Ownerチームが不明だが必要なページ群',
+                'Ownerチーム・要or不要が不明なページ.md': 'Owner: Ownerチーム・要or不要が不明なページ群',
+            },
+            'Ownerチームが不明だが必要なページ群: 1\nOwnerチーム・要or不要が不明なページ群: 1\nOwner記名なし: 0\n',
+        ),
+    ],
+)
+def test_japanese_owner(wiki_workspace, file_maps, expected):
+    assert _run(wiki_workspace, language='Japanese', file_maps=file_maps) == expected
+
+
+@pytest.mark.parametrize(
+    ('file_maps', 'expected'),
+    [
+        (None, 'Category記載なし: 2\n'),
+        (
+            {
+                'Owner記名ありページ.md': 'Owner: @test-owner',
+                'Ownerチームが不明だが必要なページ.md': 'Owner: Ownerチームが不明だが必要なページ群',
+                'Ownerチーム・要or不要が不明なページ.md': 'Owner: Ownerチーム・要or不要が不明なページ群',
+                'Owner記名なしページ1.md': '',
+                'Owner記名なしページ2.md': 'サンプル Wiki',
+            },
+            'Category記載なし: 5\n',
+        ),
+    ],
+)
+def test_japanese_category(wiki_workspace, file_maps, expected):
+    assert _run(wiki_workspace, group_by='Category', language='Japanese', file_maps=file_maps) == expected

--- a/python/test/test_unknown_wiki_list_exporter_for_llm.py
+++ b/python/test/test_unknown_wiki_list_exporter_for_llm.py
@@ -1,91 +1,28 @@
-from unknown_wiki_list_exporter_for_llm import UnknownWikiListExporterForLLM
-import sys
 import os
-import unittest
-sys.path.append('./src')
-sys.path.append('./test')
-from test_application import TestApplication
+
+from unknown_wiki_list_exporter_for_llm import UnknownWikiListExporterForLLM
 
 
-class TestUnknownWikiListExporterForLLM(TestApplication):
-    def setUp(self, group_by='Owner', language='English'):
-        super().setUp(group_by=group_by, language=language)
-        UnknownWikiListExporterForLLM(
-            base_path=self.base_path,
-            group_by=group_by,
-            language=language).run()
-        path_to_unknown_wiki_list_for_llm = os.path.join(
-            self.base_path, 'unknown_wiki_list_for_llm.txt')
-        with open(path_to_unknown_wiki_list_for_llm) as f:
-            self.unknown_wiki_list_for_llm = f.read()
+def _run(wiki_workspace, group_by='Owner', language='English'):
+    base_path = wiki_workspace(group_by=group_by, language=language)
+    UnknownWikiListExporterForLLM(base_path=base_path, group_by=group_by, language=language).run()
+    with open(os.path.join(base_path, 'unknown_wiki_list_for_llm.txt')) as f:
+        return f.read()
 
 
-class EnglishOwnershipTest(TestUnknownWikiListExporterForLLM):
-    def test_run(self):
-        self.assertEqual(
-            self.unknown_wiki_list_for_llm,
-            self.__unknown_wiki_list_for_llm__())
-
-    # private
-
-    def __unknown_wiki_list_for_llm__(self):
-        return 'Unknown Owner nor Necessity Wiki.md\n'
+def test_english_ownership(wiki_workspace):
+    assert _run(wiki_workspace) == 'Unknown Owner nor Necessity Wiki.md\n'
 
 
-class EnglishCategoryTest(TestUnknownWikiListExporterForLLM):
-    def setUp(self):
-        super().setUp(group_by='Category')
-
-    def test_run(self):
-        self.assertEqual(
-            self.unknown_wiki_list_for_llm, ''.join(
-                self.__unknown_wiki_list_for_llm__()))
-
-    # private
-
-    def __unknown_wiki_list_for_llm__(self):
-        lst = [
-            'Uncategorised Wiki 1.md\n',
-            'Uncategorised Wiki 2.md\n'
-        ]
-
-        return lst
+def test_english_category(wiki_workspace):
+    assert _run(wiki_workspace, group_by='Category') == \
+        'Uncategorised Wiki 1.md\nUncategorised Wiki 2.md\n'
 
 
-class JapaneseOwnershipTest(TestUnknownWikiListExporterForLLM):
-    def setUp(self):
-        super().setUp(language='Japanese')
-
-    def test_run(self):
-        self.assertEqual(
-            self.unknown_wiki_list_for_llm,
-            self.__unknown_wiki_list_for_llm__())
-
-    # private
-
-    def __unknown_wiki_list_for_llm__(self):
-        return 'Ownerチーム・要or不要が不明なページ.md\n'
+def test_japanese_ownership(wiki_workspace):
+    assert _run(wiki_workspace, language='Japanese') == 'Ownerチーム・要or不要が不明なページ.md\n'
 
 
-class JapaneseCategoryTest(TestUnknownWikiListExporterForLLM):
-    def setUp(self):
-        super().setUp(group_by='Category', language='Japanese')
-
-    def test_run(self):
-        self.assertEqual(
-            self.unknown_wiki_list_for_llm, ''.join(
-                self.__unknown_wiki_list_for_llm__()))
-
-    # private
-
-    def __unknown_wiki_list_for_llm__(self):
-        lst = [
-            'Category記載なしページ1.md\n',
-            'Category記載なしページ2.md\n'
-        ]
-
-        return lst
-
-
-if __name__ == '__main__':
-    unittest.main()
+def test_japanese_category(wiki_workspace):
+    assert _run(wiki_workspace, group_by='Category', language='Japanese') == \
+        'Category記載なしページ1.md\nCategory記載なしページ2.md\n'


### PR DESCRIPTION
## 1. Overview

Migrate the Python test suite from the standard library's `unittest` to `pytest`, adopting idiomatic pytest patterns (plain functions, fixtures, `assert`, `parametrize`) to reduce boilerplate and improve readability.

## 2. Changes

- Replace `unittest.TestCase` subclasses with plain test functions.
- Replace `setUp` / `tearDown` with pytest fixtures:
  - An autouse `_cleanup_pycaches` fixture in each `conftest.py` removes the per-file `glob` / `shutil.rmtree` `__pycache__` cleanup that was duplicated across every test module.
  - Per-suite state (object construction, temp directories, file workspaces) becomes regular or factory fixtures.
- Replace `self.assertEqual` / `assertTrue` / `assertFalse` / `assertIsNone` etc. with `assert` expressions.
- Replace `self.assertRaises(Cls) as cm` / `str(cm.exception) == "..."` with `pytest.raises(Cls, match=r"...")`.
- Collapse `TestCase`-subclass-as-parameter patterns into `@pytest.mark.parametrize`.
- Replace `contextlib.redirect_stdout` / custom `redirect_stdin` helpers with pytest's `capsys` and `monkeypatch` (`monkeypatch.setattr('sys.stdin', io.StringIO(...))`).
- Move shared `sys.path.append('./src')` (and friends) out of every test file into the test directory's `conftest.py`.

## 3. Summary

The result is a smaller, more uniform test suite: shared setup is declared once per test directory rather than re-implemented per file, assertions read as plain Python expressions, and parameterised cases use a single function with an explicit data table instead of a subclass hierarchy. There is no change in test coverage or assertion intent; this is a pure framework swap.

## 4. Others

- Run the suite locally with `pytest` from the project root after installing dependencies (`pip install -r requirements.txt`).
- The autouse `_cleanup_pycaches` fixture preserves the original behaviour of wiping any `__pycache__` directories created during a test run.
- No changes to `src/` are included in this PR — only the `test/` directory (and, where applicable, `requirements.txt` to declare `pytest`, and the CI workflow if it previously invoked `python -m unittest`).
