### PR TITLE
[python] Install Type Checking

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -75,14 +75,14 @@ jobs:
       - name: pytest
         working-directory: ./python
         run: pytest
-  # mypy:
-  #   timeout-minutes: 10
-  #   runs-on: ubuntu-latest
-  #   needs: change-detection
-  #   if: needs.change-detection.outputs.python-changes == 'true'
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #     - uses: ./.github/actions/setup-python
-  #     - name: mypy
-  #       working-directory: ./python
-  #       run: mypy .
+  mypy:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    needs: change-detection
+    if: needs.change-detection.outputs.python-changes == 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-python
+      - name: mypy
+        working-directory: ./python
+        run: mypy .

--- a/python/exec/export_unknown_wiki_count_list_by_namespace.py
+++ b/python/exec/export_unknown_wiki_count_list_by_namespace.py
@@ -6,7 +6,7 @@ import glob
 sys.path.append('./src')
 
 
-_, group_by, language, *_ = sys.argv
+_, group_by, language, *_rest = sys.argv
 params = dict()
 for key, value in {'group_by': group_by, 'language': language}.items():
     if value:

--- a/python/exec/export_unknown_wiki_list_for_llm.py
+++ b/python/exec/export_unknown_wiki_list_for_llm.py
@@ -6,7 +6,7 @@ import glob
 sys.path.append('./src')
 
 
-_, group_by, language, *_ = sys.argv
+_, group_by, language, *_rest = sys.argv
 params = dict()
 for key, value in {'group_by': group_by, 'language': language}.items():
     if value:

--- a/python/exec/update_wiki_list_on_home_and_sidebar.py
+++ b/python/exec/update_wiki_list_on_home_and_sidebar.py
@@ -7,7 +7,7 @@ import glob
 sys.path.append('./src')
 
 
-_, group_by, language, home_overflow, *_ = sys.argv
+_, group_by, language, home_overflow, *_rest = sys.argv
 params = dict()
 for key, value in {'group_by': group_by, 'language': language,
                    'home_overflow': home_overflow}.items():

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.mypy]
+python_version = "3.14"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true

--- a/python/requirements.lock
+++ b/python/requirements.lock
@@ -1,9 +1,9 @@
-ast_serialize==0.3.0
+ast_serialize==0.5.0
 autoflake8==0.4.1
 autopep8==2.3.2
 flake8==7.3.0
 iniconfig==2.3.0
-librt==0.10.0
+librt==0.11.0
 mccabe==0.7.0
 mypy==2.0.0
 mypy_extensions==1.1.0

--- a/python/src/application.py
+++ b/python/src/application.py
@@ -2,17 +2,18 @@ import os
 import glob
 import re
 from collections import defaultdict
+from typing import Any
 
 
 class Application:
     def __init__(
             self,
-            base_path=os.path.join(
+            base_path: str = os.path.join(
                 '..',
                 '..'),
-            group_by='Owner',
-            language='English',
-            home_overflow='False'):
+            group_by: str = 'Owner',
+            language: str = 'English',
+            home_overflow: str | bool = 'False') -> None:
         match home_overflow:
             case 'True':
                 home_overflow = True
@@ -22,37 +23,41 @@ class Application:
             group_by=group_by,
             language=language,
             home_overflow=home_overflow)
-        self.base_path = base_path
-        self.group_by = group_by
-        self.language = language
-        self.home_overflow = home_overflow
-        self.path_to_home = os.path.join(base_path, 'Home.md')
-        self.path_to_sidebar = os.path.join(base_path, '_Sidebar.md')
-        self.path_to_github_wiki_organisers = sorted(
+        self.base_path: str = base_path
+        self.group_by: str = group_by
+        self.language: str = language
+        self.home_overflow: str | bool = home_overflow
+        self.path_to_home: str = os.path.join(base_path, 'Home.md')
+        self.path_to_sidebar: str = os.path.join(base_path, '_Sidebar.md')
+        self.path_to_github_wiki_organisers: list[str] = sorted(
             glob.glob(
                 os.path.join(
                     base_path,
                     'github-wiki-organisers',
                     '**',
                     '*.md')))
-        self.path_to_wikis_by_owner = sorted(
+        self.path_to_wikis_by_owner: list[str] = sorted(
             glob.glob(
                 os.path.join(
                     base_path,
                     'wikis-by-owner',
                     '*.md')))
-        self.target_paths = self.__target_paths__()
-        self.wiki_maps_with_namespace = self.__wiki_maps_with_namespace__()
+        self.target_paths: list[str] = self.__target_paths__()
+        self.wiki_maps_with_namespace: dict[str, list[str]] = \
+            self.__wiki_maps_with_namespace__()
+        self.owned_wiki_maps: dict[str, list[str]]
+        self.plain_wiki_maps: dict[str, list[str]]
         self.owned_wiki_maps, self.plain_wiki_maps = self.__filter_namespace__()
 
-    def run(self):
+    def run(self) -> Any:
         raise NotImplementedError(
             'This method must be implemented in each subclass.')
 
     # private
 
     # @raises [ValueError]
-    def __validate__(self, group_by, language, home_overflow):
+    def __validate__(self, group_by: str, language: str,
+                     home_overflow: str | bool) -> None:
         if group_by not in ['Owner', 'Category']:
             raise ValueError(f'Invalid group_by: `{group_by}`')
         if language not in ['English', 'Japanese']:
@@ -62,7 +67,7 @@ class Application:
                 f'Invalid home_overflow: `{home_overflow}` must be boolean')
 
     # @return [str]
-    def __target_paths__(self):
+    def __target_paths__(self) -> list[str]:
         target_paths = sorted(
             glob.glob(
                 os.path.join(
@@ -73,7 +78,12 @@ class Application:
 
         for target_path in target_paths:
             match target_path:
-                case self.path_to_home | self.path_to_sidebar | self.path_to_github_wiki_organisers | self.path_to_wikis_by_owner:
+                case (
+                    self.path_to_home
+                    | self.path_to_sidebar
+                    | self.path_to_github_wiki_organisers
+                    | self.path_to_wikis_by_owner
+                ):
                     target_paths.remove(target_path)
                 case _:
                     continue
@@ -81,15 +91,17 @@ class Application:
         return target_paths
 
     # @return [regex]
-    def __target_regexp__(self):
+    def __target_regexp__(self) -> re.Pattern[str]:
         match self.group_by:
             case 'Owner':
                 return re.compile(r'[Oo]wner:\s?')
             case 'Category':
                 return re.compile(r'[Cc]ategory:\s?')
+            case _:
+                raise ValueError(f'Invalid group_by: `{self.group_by}`')
 
     # @return [str]
-    def __no_declaration__(self):
+    def __no_declaration__(self) -> str:
         match self.group_by:
             case 'Owner':
                 match self.language:
@@ -97,18 +109,26 @@ class Application:
                         return 'Unowned'
                     case 'Japanese':
                         return 'Owner記名なし'
+                    case _:
+                        raise ValueError(
+                            f'Invalid language: `{self.language}`')
             case 'Category':
                 match self.language:
                     case 'English':
                         return 'Uncategorised'
                     case 'Japanese':
                         return 'Category記載なし'
+                    case _:
+                        raise ValueError(
+                            f'Invalid language: `{self.language}`')
+            case _:
+                raise ValueError(f'Invalid group_by: `{self.group_by}`')
 
     # @return [dict<str => list<str>>]
-    def __wiki_maps_with_namespace__(self):
-        hash = defaultdict(list)
-        uncategrised_wiki_maps = defaultdict(list)
-        wiki_maps_with_namespace = defaultdict(list)
+    def __wiki_maps_with_namespace__(self) -> dict[str, list[str]]:
+        hash: defaultdict[str, list[str]] = defaultdict(list)
+        uncategrised_wiki_maps: defaultdict[str, list[str]] = defaultdict(list)
+        wiki_maps_with_namespace: dict[str, list[str]] = defaultdict(list)
 
         for target_path in self.target_paths:
             if not os.path.isfile(target_path):
@@ -138,9 +158,10 @@ class Application:
         return wiki_maps_with_namespace
 
     # @return [dict<str => list<str>>]
-    def __filter_namespace__(self):
-        owned_wiki_maps = {}
-        plain_wiki_maps = {}
+    def __filter_namespace__(
+            self) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+        owned_wiki_maps: dict[str, list[str]] = {}
+        plain_wiki_maps: dict[str, list[str]] = {}
 
         for namespace, wikis in self.wiki_maps_with_namespace.items():
             if re.search(r'@', namespace):

--- a/python/src/home.py
+++ b/python/src/home.py
@@ -15,42 +15,42 @@ HOME_URL = f'https://github.com/{
 class Home(Application):
     def __init__(
             self,
-            base_path=os.path.join(
+            base_path: str = os.path.join(
                 '..',
                 '..'),
-            group_by='Owner',
-            language='English',
-            home_overflow=False):
+            group_by: str = 'Owner',
+            language: str = 'English',
+            home_overflow: str | bool = False) -> None:
         super().__init__(base_path, group_by, language, home_overflow)
-        self.base_owner_url = f'https://github.com/orgs/{
+        self.base_owner_url: str = f'https://github.com/orgs/{
             os.environ.get(
                 'ORGANISATION_NAME',
                 'hayat01sh1da')}/teams/'
-        self.home_passage = self.__home_passage__()
-        self.path_to_wikis_by_owner = os.path.join(
+        self.home_passage: str = self.__home_passage__()
+        self.path_to_wikis_by_owner_dir: str = os.path.join(
             self.base_path, 'wikis-by-owner')
 
-    def run(self):
+    def run(self) -> str:
         self.__write_home_passage__()
         return HOME_URL
 
     # private
 
     # @return [str]
-    def __path_to_home_template__(self):
+    def __path_to_home_template__(self) -> str:
         return os.path.join(
             '..', 'home_template', self.group_by.lower(), f'{
                 self.language.lower()}.md')
 
     # @return [list<str>]
-    def __home_passage__(self):
+    def __home_passage__(self) -> str:
         with open(self.__path_to_home_template__()) as f:
             return f.read() + '\n'
 
     # @return [str]
-    def __write_home_passage__(self):
+    def __write_home_passage__(self) -> None:
         if self.home_overflow:
-            os.makedirs(self.path_to_wikis_by_owner, exist_ok=True)
+            os.makedirs(self.path_to_wikis_by_owner_dir, exist_ok=True)
 
             for namespace, wikis in self.owned_wiki_maps.items():
                 self.__write_wikis_by_owner_file__(
@@ -73,8 +73,8 @@ class Home(Application):
                 f.write(self.home_passage.rstrip() + '\n')
 
         else:
-            if os.path.exists(self.path_to_wikis_by_owner):
-                shutil.rmtree(self.path_to_wikis_by_owner)
+            if os.path.exists(self.path_to_wikis_by_owner_dir):
+                shutil.rmtree(self.path_to_wikis_by_owner_dir)
             for namespace, wikis in self.owned_wiki_maps.items():
                 self.home_passage += f'## [{namespace}]({
                     self.base_owner_url +
@@ -97,7 +97,8 @@ class Home(Application):
             with open(self.path_to_home, 'w') as f:
                 f.write(self.home_passage.rstrip() + '\n')
 
-    def __write_wikis_by_owner_file__(self, namespace, wikis, owned):
+    def __write_wikis_by_owner_file__(
+            self, namespace: str, wikis: list[str], owned: bool) -> None:
         home_passage = ''
         if owned:
             home_passage += f'## [{namespace}]({
@@ -114,7 +115,7 @@ class Home(Application):
         home_passage += '\n'
 
         file_path = os.path.join(
-            self.path_to_wikis_by_owner,
+            self.path_to_wikis_by_owner_dir,
             f'{namespace}.md')
         with open(file_path, 'w') as f:
             f.write(home_passage.rstrip() + '\n')

--- a/python/src/sidebar.py
+++ b/python/src/sidebar.py
@@ -8,27 +8,27 @@ sys.path.append('./src')
 class Sidebar(Application):
     def __init__(
             self,
-            base_path=os.path.join(
+            base_path: str = os.path.join(
                 '..',
                 '..'),
-            group_by='Owner',
-            language='English',
-            home_overflow=False):
+            group_by: str = 'Owner',
+            language: str = 'English',
+            home_overflow: str | bool = False) -> None:
         super().__init__(base_path, group_by, language, home_overflow)
-        self.base_owner_url = f'https://github.com/orgs/{
+        self.base_owner_url: str = f'https://github.com/orgs/{
             os.environ.get(
                 'ORGANISATION_NAME',
                 'hayat01sh1da')}/teams/'
-        self.wiki_list = self.__write_wiki_list__()
+        self.wiki_list: str = self.__write_wiki_list__()
 
-    def run(self):
+    def run(self) -> None:
         with open(self.path_to_sidebar, 'w') as f:
             f.write(self.wiki_list)
 
     # private
 
     # @return [str]
-    def __write_wiki_list__(self):
+    def __write_wiki_list__(self) -> str:
         wiki_list = ''
 
         for namespace, wikis in self.owned_wiki_maps.items():

--- a/python/src/unknown_wiki_count_list_exporter.py
+++ b/python/src/unknown_wiki_count_list_exporter.py
@@ -7,19 +7,19 @@ sys.path.append('./src')
 class UnknownWikiCountListExporter(Application):
     def __init__(
             self,
-            base_path=os.path.join(
+            base_path: str = os.path.join(
                 '..',
                 '..'),
-            group_by='Owner',
-            language='English',
-            home_overflow=False):
+            group_by: str = 'Owner',
+            language: str = 'English',
+            home_overflow: str | bool = False) -> None:
         super().__init__(base_path, group_by, language, home_overflow)
-        self.path_to_export = os.path.join(
+        self.path_to_export: str = os.path.join(
             self.base_path, 'unknown_wiki_count_list_by_namespace.txt')
-        self.count_list_by_namespace = ''.join(
+        self.count_list_by_namespace: str = ''.join(
             sorted(self.__count_list_by_namespace__()))
 
-    def run(self):
+    def run(self) -> tuple[str, str]:
         with open(self.path_to_export, 'w') as f:
             f.write(self.count_list_by_namespace.rstrip() + '\n')
 
@@ -28,7 +28,7 @@ class UnknownWikiCountListExporter(Application):
     # private
 
     # @return [list<str>]
-    def __namespace_list__(self):
+    def __namespace_list__(self) -> list[str]:
         match self.group_by:
             case 'Owner':
                 match self.language:
@@ -44,6 +44,9 @@ class UnknownWikiCountListExporter(Application):
                             'Ownerチーム・要or不要が不明なページ群',
                             'Owner記名なし'
                         ]
+                    case _:
+                        raise ValueError(
+                            f'Invalid language: `{self.language}`')
             case 'Category':
                 match self.language:
                     case 'English':
@@ -54,18 +57,23 @@ class UnknownWikiCountListExporter(Application):
                         return [
                             'Category記載なし'
                         ]
+                    case _:
+                        raise ValueError(
+                            f'Invalid language: `{self.language}`')
+            case _:
+                raise ValueError(f'Invalid group_by: `{self.group_by}`')
 
     # @return [list<str>]
-    def __count_list_by_namespace__(self):
-        filtered_count_list_by_namespace = {}
-        count_list_by_namespace = []
+    def __count_list_by_namespace__(self) -> list[str]:
+        filtered_count_list_by_namespace: dict[str, list[str]] = {}
+        count_list_by_namespace: list[str] = []
 
         for namespace, wikis in self.plain_wiki_maps.items():
             if namespace in self.__namespace_list__():
                 filtered_count_list_by_namespace[namespace] = wikis
 
         for namespace in (
-                self.__namespace_list__() -
+                self.__namespace_list__() -  # type: ignore[operator]
                 filtered_count_list_by_namespace.keys()):
             count_list_by_namespace.append(f'{namespace}: 0\n')
 

--- a/python/src/unknown_wiki_list_exporter_for_llm.py
+++ b/python/src/unknown_wiki_list_exporter_for_llm.py
@@ -7,19 +7,19 @@ sys.path.append('./src')
 class UnknownWikiListExporterForLLM(Application):
     def __init__(
             self,
-            base_path=os.path.join(
+            base_path: str = os.path.join(
                 '..',
                 '..'),
-            group_by='Owner',
-            language='English',
-            home_overflow=False):
+            group_by: str = 'Owner',
+            language: str = 'English',
+            home_overflow: str | bool = False) -> None:
         super().__init__(base_path, group_by, language, home_overflow)
-        self.path_to_export = os.path.join(
+        self.path_to_export: str = os.path.join(
             self.base_path, 'unknown_wiki_list_for_llm.txt')
-        self.unknown_wiki_list_for_llm = ''.join(
+        self.unknown_wiki_list_for_llm: str = ''.join(
             sorted(self.__unknown_wiki_list_for_llm__()))
 
-    def run(self):
+    def run(self) -> str:
         with open(self.path_to_export, 'w') as f:
             f.write(self.unknown_wiki_list_for_llm.rstrip() + '\n')
 
@@ -28,7 +28,7 @@ class UnknownWikiListExporterForLLM(Application):
     # private
 
     # @return [str]
-    def __target_namespace__(self):
+    def __target_namespace__(self) -> str:
         match self.group_by:
             case 'Owner':
                 match self.language:
@@ -36,16 +36,24 @@ class UnknownWikiListExporterForLLM(Application):
                         return 'Unknown Owner nor Necessity'
                     case 'Japanese':
                         return 'Ownerチーム・要or不要が不明なページ群'
+                    case _:
+                        raise ValueError(
+                            f'Invalid language: `{self.language}`')
             case 'Category':
                 match self.language:
                     case 'English':
                         return 'Uncategorised'
                     case 'Japanese':
                         return 'Category記載なし'
+                    case _:
+                        raise ValueError(
+                            f'Invalid language: `{self.language}`')
+            case _:
+                raise ValueError(f'Invalid group_by: `{self.group_by}`')
 
     # @return [list<str>]
-    def __unknown_wiki_list_for_llm__(self):
-        unknown_wiki_list_for_llm = []
+    def __unknown_wiki_list_for_llm__(self) -> list[str]:
+        unknown_wiki_list_for_llm: list[str] = []
 
         for namespace, wikis in self.plain_wiki_maps.items():
             if namespace == self.__target_namespace__():

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-import glob
+import re
 import os
 import shutil
 import sys
@@ -38,17 +38,13 @@ _DEFAULT_FILE_MAPS = {
 
 @pytest.fixture(autouse=True)
 def __cleanup_caches__() -> Iterator[None]:
-    before = set(
-        glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True))
     yield
-    for pycache in before:
-        if os.path.exists(pycache):
-            shutil.rmtree(pycache)
+    cache_dir = re.compile(r'^(?:__pycache__|\.pytest_cache|\.mypy_cache)$')
+    for root, dirs, _ in os.walk('.'):
+        for name in list(dirs):
+            if cache_dir.match(name):
+                shutil.rmtree(os.path.join(root, name), ignore_errors=True)
+                dirs.remove(name)
 
 
 @pytest.fixture

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -1,12 +1,11 @@
+import pytest
 import glob
 import os
 import shutil
 import sys
+from collections.abc import Callable, Iterator
 
 sys.path.append('./src')
-
-
-import pytest
 
 
 _DEFAULT_FILE_MAPS = {
@@ -38,8 +37,14 @@ _DEFAULT_FILE_MAPS = {
 
 
 @pytest.fixture(autouse=True)
-def _cleanup_pycaches():
-    before = set(glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True))
+def __cleanup_caches__() -> Iterator[None]:
+    before = set(
+        glob.glob(
+            os.path.join(
+                '.',
+                '**',
+                '__pycache__'),
+            recursive=True))
     yield
     for pycache in before:
         if os.path.exists(pycache):
@@ -47,10 +52,11 @@ def _cleanup_pycaches():
 
 
 @pytest.fixture
-def wiki_workspace():
+def wiki_workspace() -> Iterator[Callable[..., str]]:
     base_path = os.path.join('.', 'test', 'wiki')
 
-    def _build(group_by='Owner', language='English', file_maps=None):
+    def _build(group_by: str = 'Owner', language: str = 'English',
+               file_maps: dict[str, str] | None = None) -> str:
         if file_maps is None:
             file_maps = _DEFAULT_FILE_MAPS[(group_by, language)]
         os.makedirs(base_path, exist_ok=True)

--- a/python/test/test_application.py
+++ b/python/test/test_application.py
@@ -1,27 +1,46 @@
+from collections.abc import Callable
+
 import pytest
 
 from application import Application
 
 
-def test_validate_group_by(wiki_workspace):
+def test_validate_group_by(wiki_workspace: Callable[..., str]) -> None:
     base_path = wiki_workspace()
     with pytest.raises(ValueError, match=r'^Invalid group_by: `Group`$'):
-        Application(base_path=base_path, group_by='Group', language='English', home_overflow=False)
+        Application(
+            base_path=base_path,
+            group_by='Group',
+            language='English',
+            home_overflow=False)
 
 
-def test_validate_language(wiki_workspace):
+def test_validate_language(wiki_workspace: Callable[..., str]) -> None:
     base_path = wiki_workspace()
     with pytest.raises(ValueError, match=r'^Invalid language: `Spanish`$'):
-        Application(base_path=base_path, group_by='Owner', language='Spanish', home_overflow=False)
+        Application(
+            base_path=base_path,
+            group_by='Owner',
+            language='Spanish',
+            home_overflow=False)
 
 
-def test_validate_home_overflow(wiki_workspace):
+def test_validate_home_overflow(wiki_workspace: Callable[..., str]) -> None:
     base_path = wiki_workspace()
     with pytest.raises(ValueError, match=r'^Invalid home_overflow: `foo` must be boolean$'):
-        Application(base_path=base_path, group_by='Owner', language='English', home_overflow='foo')
+        Application(
+            base_path=base_path,
+            group_by='Owner',
+            language='English',
+            home_overflow='foo')
 
 
-def test_run_raises_not_implemented(wiki_workspace):
+def test_run_raises_not_implemented(
+        wiki_workspace: Callable[..., str]) -> None:
     base_path = wiki_workspace()
     with pytest.raises(NotImplementedError, match=r'^This method must be implemented in each subclass\.$'):
-        Application(base_path=base_path, group_by='Owner', language='English', home_overflow=False).run()
+        Application(
+            base_path=base_path,
+            group_by='Owner',
+            language='English',
+            home_overflow=False).run()

--- a/python/test/test_home.py
+++ b/python/test/test_home.py
@@ -1,21 +1,36 @@
 import glob
 import os
+from collections.abc import Callable
 
 from home import Home
 
 
-def _run_home(wiki_workspace, group_by='Owner', language='English', home_overflow=False):
+def _run_home(wiki_workspace: Callable[..., str], group_by: str = 'Owner',
+              language: str = 'English',
+              home_overflow: bool = False) -> tuple[str, str, list[str]]:
     base_path = wiki_workspace(group_by=group_by, language=language)
-    Home(base_path=base_path, group_by=group_by, language=language, home_overflow=home_overflow).run()
+    Home(
+        base_path=base_path,
+        group_by=group_by,
+        language=language,
+        home_overflow=home_overflow).run()
     with open(os.path.join(base_path, 'Home.md')) as f:
         home = f.read()
     path_to_wikis_by_owner = os.path.join(base_path, 'wikis-by-owner')
-    overflow_files = sorted(glob.glob(os.path.join(path_to_wikis_by_owner, '*.md')))
+    overflow_files = sorted(
+        glob.glob(
+            os.path.join(
+                path_to_wikis_by_owner,
+                '*.md')))
     return home, path_to_wikis_by_owner, overflow_files
 
 
-def _expected_wikis_by_owner(path_to_wikis_by_owner, namespaces):
-    return sorted(os.path.join(path_to_wikis_by_owner, f'{namespace}.md') for namespace in namespaces)
+def _expected_wikis_by_owner(path_to_wikis_by_owner: str,
+                             namespaces: list[str]) -> list[str]:
+    return sorted(
+        os.path.join(
+            path_to_wikis_by_owner,
+            f'{namespace}.md') for namespace in namespaces)
 
 
 _ENGLISH_OWNED_HOME = (
@@ -23,12 +38,15 @@ _ENGLISH_OWNED_HOME = (
     '\n'
     'This Home page manage wikis by owner group.\n'
     '\n'
-    'Absence of ownership declaration worsens maintainability and searchability because it makes ambiguous which team the responsibility belongs to.  \n'
+    'Absence of ownership declaration worsens maintainability and '
+    'searchability because it makes ambiguous which team the '
+    'responsibility belongs to.  \n'
     'Kindly make sure to articulate `Owner: @OWNER_TEAM` of the top of each of your wiki page to avoid it.\n'
     '\n'
-    'Also, please keep in mind that you do not have to edit Home and Sidebar by yourself, which are automatically updated by a GitHub Actions cron job.\n'
-    '\n'
-)
+    'Also, please keep in mind that you do not have to edit Home and '
+    'Sidebar by yourself, which are automatically updated by a '
+    'GitHub Actions cron job.\n'
+    '\n')
 _ENGLISH_OWNED_HOME_WITHOUT_OVERFLOW = _ENGLISH_OWNED_HOME + (
     '## [@test-owner](https://github.com/orgs/hayat01sh1da/teams/test-owner)\n'
     '\n'
@@ -61,7 +79,9 @@ _ENGLISH_CATEGORISED_HOME = (
     'Absence of category declaration worsens maintainability and searchability.  \n'
     'Kindly make sure to articulate `Category: CATEGORY_NAME` of the top of each of your wiki page to avoid it.\n'
     '\n'
-    'Also, please keep in mind that you do not have to edit Home and Sidebar by yourself, which are automatically updated by a GitHub Actions cron job.\n'
+    'Also, please keep in mind that you do not have to edit Home and '
+    'Sidebar by yourself, which are automatically updated by a '
+    'GitHub Actions cron job.\n'
     '\n'
     '## test-category\n'
     '\n'
@@ -70,8 +90,7 @@ _ENGLISH_CATEGORISED_HOME = (
     '## Uncategorised\n'
     '\n'
     '- [[Uncategorised Wiki 1]]\n'
-    '- [[Uncategorised Wiki 2]]\n'
-)
+    '- [[Uncategorised Wiki 2]]\n')
 _JAPANESE_OWNED_HOME = (
     '## Wiki ページの運用ルール\n'
     '\n'
@@ -128,14 +147,17 @@ _JAPANESE_CATEGORISED_HOME = (
 )
 
 
-def test_english_owned_home_without_overflow(wiki_workspace):
+def test_english_owned_home_without_overflow(
+        wiki_workspace: Callable[..., str]) -> None:
     home, path_to_wikis_by_owner, _ = _run_home(wiki_workspace)
     assert not os.path.exists(path_to_wikis_by_owner)
     assert home == _ENGLISH_OWNED_HOME_WITHOUT_OVERFLOW
 
 
-def test_english_owned_home_with_overflow(wiki_workspace):
-    home, path_to_wikis_by_owner, overflow_files = _run_home(wiki_workspace, home_overflow=True)
+def test_english_owned_home_with_overflow(
+        wiki_workspace: Callable[..., str]) -> None:
+    home, path_to_wikis_by_owner, overflow_files = _run_home(
+        wiki_workspace, home_overflow=True)
     assert os.path.exists(path_to_wikis_by_owner)
     assert home == _ENGLISH_OWNED_HOME_WITH_OVERFLOW
     assert overflow_files == _expected_wikis_by_owner(
@@ -144,18 +166,22 @@ def test_english_owned_home_with_overflow(wiki_workspace):
     )
 
 
-def test_english_categorised_home(wiki_workspace):
+def test_english_categorised_home(
+        wiki_workspace: Callable[..., str]) -> None:
     home, _, _ = _run_home(wiki_workspace, group_by='Category')
     assert home == _ENGLISH_CATEGORISED_HOME
 
 
-def test_japanese_owned_home_without_overflow(wiki_workspace):
-    home, path_to_wikis_by_owner, _ = _run_home(wiki_workspace, language='Japanese')
+def test_japanese_owned_home_without_overflow(
+        wiki_workspace: Callable[..., str]) -> None:
+    home, path_to_wikis_by_owner, _ = _run_home(
+        wiki_workspace, language='Japanese')
     assert not os.path.exists(path_to_wikis_by_owner)
     assert home == _JAPANESE_OWNED_HOME_WITHOUT_OVERFLOW
 
 
-def test_japanese_owned_home_with_overflow(wiki_workspace):
+def test_japanese_owned_home_with_overflow(
+        wiki_workspace: Callable[..., str]) -> None:
     home, path_to_wikis_by_owner, overflow_files = _run_home(
         wiki_workspace, language='Japanese', home_overflow=True,
     )
@@ -167,6 +193,8 @@ def test_japanese_owned_home_with_overflow(wiki_workspace):
     )
 
 
-def test_japanese_categorised_home(wiki_workspace):
-    home, _, _ = _run_home(wiki_workspace, group_by='Category', language='Japanese')
+def test_japanese_categorised_home(
+        wiki_workspace: Callable[..., str]) -> None:
+    home, _, _ = _run_home(
+        wiki_workspace, group_by='Category', language='Japanese')
     assert home == _JAPANESE_CATEGORISED_HOME

--- a/python/test/test_sidebar.py
+++ b/python/test/test_sidebar.py
@@ -1,9 +1,11 @@
 import os
+from collections.abc import Callable
 
 from sidebar import Sidebar
 
 
-def _run_sidebar(wiki_workspace, group_by='Owner', language='English'):
+def _run_sidebar(wiki_workspace: Callable[..., str], group_by: str = 'Owner',
+                 language: str = 'English') -> str:
     base_path = wiki_workspace(group_by=group_by, language=language)
     Sidebar(base_path, group_by=group_by, language=language).run()
     with open(os.path.join(base_path, '_Sidebar.md')) as f:
@@ -48,17 +50,20 @@ _JAPANESE_PLAIN = (
 )
 
 
-def test_english_owned_sidebar(wiki_workspace):
+def test_english_owned_sidebar(wiki_workspace: Callable[..., str]) -> None:
     assert _run_sidebar(wiki_workspace) == _ENGLISH_OWNED
 
 
-def test_english_plain_sidebar(wiki_workspace):
+def test_english_plain_sidebar(wiki_workspace: Callable[..., str]) -> None:
     assert _run_sidebar(wiki_workspace, group_by='Category') == _ENGLISH_PLAIN
 
 
-def test_japanese_owned_sidebar(wiki_workspace):
+def test_japanese_owned_sidebar(wiki_workspace: Callable[..., str]) -> None:
     assert _run_sidebar(wiki_workspace, language='Japanese') == _JAPANESE_OWNED
 
 
-def test_japanese_plain_sidebar(wiki_workspace):
-    assert _run_sidebar(wiki_workspace, group_by='Category', language='Japanese') == _JAPANESE_PLAIN
+def test_japanese_plain_sidebar(wiki_workspace: Callable[..., str]) -> None:
+    assert _run_sidebar(
+        wiki_workspace,
+        group_by='Category',
+        language='Japanese') == _JAPANESE_PLAIN

--- a/python/test/test_unknown_wiki_count_list_exporter.py
+++ b/python/test/test_unknown_wiki_count_list_exporter.py
@@ -1,131 +1,130 @@
 import os
+from collections.abc import Callable
 
 import pytest
 
 from unknown_wiki_count_list_exporter import UnknownWikiCountListExporter
 
 
-def _run(wiki_workspace, group_by='Owner', language='English', file_maps=None):
-    base_path = wiki_workspace(group_by=group_by, language=language, file_maps=file_maps)
-    UnknownWikiCountListExporter(base_path, group_by=group_by, language=language).run()
+def _run(wiki_workspace: Callable[..., str], group_by: str = 'Owner',
+         language: str = 'English',
+         file_maps: dict[str, str] | None = None) -> str:
+    base_path = wiki_workspace(
+        group_by=group_by,
+        language=language,
+        file_maps=file_maps)
+    UnknownWikiCountListExporter(
+        base_path,
+        group_by=group_by,
+        language=language).run()
     with open(os.path.join(base_path, 'unknown_wiki_count_list_by_namespace.txt')) as f:
         return f.read()
 
 
-@pytest.mark.parametrize(
-    ('file_maps', 'expected'),
-    [
-        (
-            None,
-            'Unknown Owner nor Necessity: 1\nUnowned but Necessary: 1\nUnowned: 2\n',
-        ),
-        (
-            {
-                'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
-                'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
-                'Unowned Wiki 1.md': '',
-                'Unowned Wiki 2.md': 'This is a sample Wiki',
-            },
-            'Unknown Owner nor Necessity: 1\nUnowned but Necessary: 1\nUnowned: 2\n',
-        ),
-        (
-            {
-                'Owned Wiki.md': 'Owner: @test-owner',
-                'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
-                'Unowned Wiki 1.md': '',
-                'Unowned Wiki 2.md': 'This is a sample Wiki',
-            },
-            'Unknown Owner nor Necessity: 0\nUnowned but Necessary: 1\nUnowned: 2\n',
-        ),
-        (
-            {
-                'Owned Wiki.md': 'Owner: @test-owner',
-                'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
-                'Unowned Wiki 1.md': '',
-                'Unowned Wiki 2.md': 'This is a sample Wiki',
-            },
-            'Unknown Owner nor Necessity: 1\nUnowned but Necessary: 0\nUnowned: 2\n',
-        ),
-        (
-            {
-                'Owned Wiki.md': 'Owner: @test-owner',
-                'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
-                'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
-            },
-            'Unknown Owner nor Necessity: 1\nUnowned but Necessary: 1\nUnowned: 0\n',
-        ),
-    ],
-)
-def test_english_owner(wiki_workspace, file_maps, expected):
+@pytest.mark.parametrize(('file_maps',
+                          'expected'),
+                         [(None,
+                           'Unknown Owner nor Necessity: 1\nUnowned but Necessary: 1\nUnowned: 2\n',
+                           ),
+                          ({'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
+                            'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
+                            'Unowned Wiki 1.md': '',
+                            'Unowned Wiki 2.md': 'This is a sample Wiki',
+                            },
+                           'Unknown Owner nor Necessity: 1\nUnowned but Necessary: 1\nUnowned: 2\n',
+                           ),
+                          ({'Owned Wiki.md': 'Owner: @test-owner',
+                            'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
+                            'Unowned Wiki 1.md': '',
+                            'Unowned Wiki 2.md': 'This is a sample Wiki',
+                            },
+                             'Unknown Owner nor Necessity: 0\nUnowned but Necessary: 1\nUnowned: 2\n',
+                           ),
+                          ({'Owned Wiki.md': 'Owner: @test-owner',
+                            'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
+                            'Unowned Wiki 1.md': '',
+                            'Unowned Wiki 2.md': 'This is a sample Wiki',
+                            },
+                             'Unknown Owner nor Necessity: 1\nUnowned but Necessary: 0\nUnowned: 2\n',
+                           ),
+                          ({'Owned Wiki.md': 'Owner: @test-owner',
+                            'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
+                            'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
+                            },
+                             'Unknown Owner nor Necessity: 1\nUnowned but Necessary: 1\nUnowned: 0\n',
+                           ),
+                          ],
+                         )
+def test_english_owner(wiki_workspace: Callable[..., str],
+                       file_maps: dict[str, str] | None,
+                       expected: str) -> None:
     assert _run(wiki_workspace, file_maps=file_maps) == expected
 
 
-@pytest.mark.parametrize(
-    ('file_maps', 'expected'),
-    [
-        (None, 'Uncategorised: 2\n'),
-        (
-            {
-                'Owned Wiki.md': 'Owner: @test-owner',
-                'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
-                'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
-                'Unowned Wiki 1.md': '',
-                'Unowned Wiki 2.md': 'This is a sample Wiki',
-            },
-            'Uncategorised: 5\n',
-        ),
-    ],
-)
-def test_english_category(wiki_workspace, file_maps, expected):
-    assert _run(wiki_workspace, group_by='Category', file_maps=file_maps) == expected
+@pytest.mark.parametrize(('file_maps',
+                          'expected'),
+                         [(None,
+                           'Uncategorised: 2\n'),
+                          ({'Owned Wiki.md': 'Owner: @test-owner',
+                            'Unowned but Necessary Wiki.md': 'Owner: Unowned but Necessary',
+                            'Unknown Owner nor Necessity Wiki.md': 'Owner: Unknown Owner nor Necessity',
+                            'Unowned Wiki 1.md': '',
+                            'Unowned Wiki 2.md': 'This is a sample Wiki',
+                            },
+                             'Uncategorised: 5\n',
+                           ),
+                          ],
+                         )
+def test_english_category(wiki_workspace: Callable[..., str],
+                          file_maps: dict[str, str] | None,
+                          expected: str) -> None:
+    assert _run(
+        wiki_workspace,
+        group_by='Category',
+        file_maps=file_maps) == expected
 
 
-@pytest.mark.parametrize(
-    ('file_maps', 'expected'),
-    [
-        (
-            None,
-            'Ownerチームが不明だが必要なページ群: 1\nOwnerチーム・要or不要が不明なページ群: 1\nOwner記名なし: 2\n',
-        ),
-        (
-            {
-                'Ownerチームが不明だが必要なページ.md': 'Owner: Ownerチームが不明だが必要なページ群',
-                'Ownerチーム・要or不要が不明なページ.md': 'Owner: Ownerチーム・要or不要が不明なページ群',
-                'Owner記名なしページ1.md': '',
-                'Owner記名なしページ2.md': 'サンプル Wiki',
-            },
-            'Ownerチームが不明だが必要なページ群: 1\nOwnerチーム・要or不要が不明なページ群: 1\nOwner記名なし: 2\n',
-        ),
-        (
-            {
-                'Owner記名ありページ.md': 'Owner: @test-owner',
-                'Ownerチームが不明だが必要なページ.md': 'Owner: Ownerチームが不明だが必要なページ群',
-                'Owner記名なしページ1.md': '',
-                'Owner記名なしページ2.md': 'サンプル Wiki',
-            },
-            'Ownerチームが不明だが必要なページ群: 1\nOwnerチーム・要or不要が不明なページ群: 0\nOwner記名なし: 2\n',
-        ),
-        (
-            {
-                'Owner記名ありページ.md': 'Owner: @test-owner',
-                'Ownerチーム・要or不要が不明なページ.md': 'Owner: Ownerチーム・要or不要が不明なページ群',
-                'Owner記名なしページ1.md': '',
-                'Owner記名なしページ2.md': 'サンプル Wiki',
-            },
-            'Ownerチームが不明だが必要なページ群: 0\nOwnerチーム・要or不要が不明なページ群: 1\nOwner記名なし: 2\n',
-        ),
-        (
-            {
-                'Owner記名ありページ.md': 'Owner: @test-owner',
-                'Ownerチームが不明だが必要なページ.md': 'Owner: Ownerチームが不明だが必要なページ群',
-                'Ownerチーム・要or不要が不明なページ.md': 'Owner: Ownerチーム・要or不要が不明なページ群',
-            },
-            'Ownerチームが不明だが必要なページ群: 1\nOwnerチーム・要or不要が不明なページ群: 1\nOwner記名なし: 0\n',
-        ),
-    ],
-)
-def test_japanese_owner(wiki_workspace, file_maps, expected):
-    assert _run(wiki_workspace, language='Japanese', file_maps=file_maps) == expected
+@pytest.mark.parametrize(('file_maps',
+                          'expected'),
+                         [(None,
+                           'Ownerチームが不明だが必要なページ群: 1\nOwnerチーム・要or不要が不明なページ群: 1\nOwner記名なし: 2\n',
+                           ),
+                          ({'Ownerチームが不明だが必要なページ.md': 'Owner: Ownerチームが不明だが必要なページ群',
+                            'Ownerチーム・要or不要が不明なページ.md': 'Owner: Ownerチーム・要or不要が不明なページ群',
+                            'Owner記名なしページ1.md': '',
+                            'Owner記名なしページ2.md': 'サンプル Wiki',
+                            },
+                           'Ownerチームが不明だが必要なページ群: 1\nOwnerチーム・要or不要が不明なページ群: 1\nOwner記名なし: 2\n',
+                           ),
+                          ({'Owner記名ありページ.md': 'Owner: @test-owner',
+                            'Ownerチームが不明だが必要なページ.md': 'Owner: Ownerチームが不明だが必要なページ群',
+                            'Owner記名なしページ1.md': '',
+                            'Owner記名なしページ2.md': 'サンプル Wiki',
+                            },
+                             'Ownerチームが不明だが必要なページ群: 1\nOwnerチーム・要or不要が不明なページ群: 0\nOwner記名なし: 2\n',
+                           ),
+                          ({'Owner記名ありページ.md': 'Owner: @test-owner',
+                            'Ownerチーム・要or不要が不明なページ.md': 'Owner: Ownerチーム・要or不要が不明なページ群',
+                            'Owner記名なしページ1.md': '',
+                            'Owner記名なしページ2.md': 'サンプル Wiki',
+                            },
+                             'Ownerチームが不明だが必要なページ群: 0\nOwnerチーム・要or不要が不明なページ群: 1\nOwner記名なし: 2\n',
+                           ),
+                          ({'Owner記名ありページ.md': 'Owner: @test-owner',
+                            'Ownerチームが不明だが必要なページ.md': 'Owner: Ownerチームが不明だが必要なページ群',
+                            'Ownerチーム・要or不要が不明なページ.md': 'Owner: Ownerチーム・要or不要が不明なページ群',
+                            },
+                             'Ownerチームが不明だが必要なページ群: 1\nOwnerチーム・要or不要が不明なページ群: 1\nOwner記名なし: 0\n',
+                           ),
+                          ],
+                         )
+def test_japanese_owner(wiki_workspace: Callable[..., str],
+                        file_maps: dict[str, str] | None,
+                        expected: str) -> None:
+    assert _run(
+        wiki_workspace,
+        language='Japanese',
+        file_maps=file_maps) == expected
 
 
 @pytest.mark.parametrize(
@@ -144,5 +143,11 @@ def test_japanese_owner(wiki_workspace, file_maps, expected):
         ),
     ],
 )
-def test_japanese_category(wiki_workspace, file_maps, expected):
-    assert _run(wiki_workspace, group_by='Category', language='Japanese', file_maps=file_maps) == expected
+def test_japanese_category(wiki_workspace: Callable[..., str],
+                           file_maps: dict[str, str] | None,
+                           expected: str) -> None:
+    assert _run(
+        wiki_workspace,
+        group_by='Category',
+        language='Japanese',
+        file_maps=file_maps) == expected

--- a/python/test/test_unknown_wiki_list_exporter_for_llm.py
+++ b/python/test/test_unknown_wiki_list_exporter_for_llm.py
@@ -1,28 +1,35 @@
 import os
+from collections.abc import Callable
 
 from unknown_wiki_list_exporter_for_llm import UnknownWikiListExporterForLLM
 
 
-def _run(wiki_workspace, group_by='Owner', language='English'):
+def _run(wiki_workspace: Callable[..., str], group_by: str = 'Owner',
+         language: str = 'English') -> str:
     base_path = wiki_workspace(group_by=group_by, language=language)
-    UnknownWikiListExporterForLLM(base_path=base_path, group_by=group_by, language=language).run()
+    UnknownWikiListExporterForLLM(
+        base_path=base_path,
+        group_by=group_by,
+        language=language).run()
     with open(os.path.join(base_path, 'unknown_wiki_list_for_llm.txt')) as f:
         return f.read()
 
 
-def test_english_ownership(wiki_workspace):
+def test_english_ownership(wiki_workspace: Callable[..., str]) -> None:
     assert _run(wiki_workspace) == 'Unknown Owner nor Necessity Wiki.md\n'
 
 
-def test_english_category(wiki_workspace):
+def test_english_category(wiki_workspace: Callable[..., str]) -> None:
     assert _run(wiki_workspace, group_by='Category') == \
         'Uncategorised Wiki 1.md\nUncategorised Wiki 2.md\n'
 
 
-def test_japanese_ownership(wiki_workspace):
-    assert _run(wiki_workspace, language='Japanese') == 'Ownerチーム・要or不要が不明なページ.md\n'
+def test_japanese_ownership(wiki_workspace: Callable[..., str]) -> None:
+    assert _run(
+        wiki_workspace,
+        language='Japanese') == 'Ownerチーム・要or不要が不明なページ.md\n'
 
 
-def test_japanese_category(wiki_workspace):
+def test_japanese_category(wiki_workspace: Callable[..., str]) -> None:
     assert _run(wiki_workspace, group_by='Category', language='Japanese') == \
         'Category記載なしページ1.md\nCategory記載なしページ2.md\n'


### PR DESCRIPTION
## 1. Why (Purpose)

Most personal Python projects had no static type checking, and code-style consistency was only partially enforced. The goals were to:

- **Introduce `mypy`** to every Python project so type regressions are caught in CI rather than at runtime.
- **Add reasonable type annotations** to the implementations (and add missing ones where mypy was partially present).
- **Enable the `mypy` job in GitHub Actions** so type checking runs on every push/PR (it was commented out in most workflows).
- **Enforce code convention** by running `autoflake8` + `autopep8` and fixing residual `flake8` violations, keeping the codebase clean and consistent.

## 2. What (Procedures)

Processed **13 Python repositories** (the `github-wiki-organisers-wiki` repo was skipped — the project is a git submodule there). Per project:

1. Ensured `mypy==2.0.0` in `requirements.txt` (added to `deep-learnings`, `natural-language-processing`).
2. Added a `[tool.mypy]` block in `pyproject.toml` (created where missing).
3. Added type annotations across `src/`, `test/`, `conftest.py`, `main.py`, `exec/` so `mypy` passes; fixed genuine type bugs found along the way (`*_` argv-unpack reuse, a literally-duplicated class in `embedding_dot.py`, a duplicated optional-import block, a missing `import urllib.parse`, `from X import *` → explicit imports).
4. Enabled the previously-commented `mypy` CI job; added `run_mypy.sh` for multi-subproject/volume repos to avoid duplicate-module collisions.
5. Ran `autoflake8 --in-place --remove-duplicate-keys --remove-unused-variables --recursive .` and `autopep8 --in-place --aggressive --aggressive --recursive .`, then fixed remaining `flake8` violations (E501, E402, E114/E131, F811, F403/F405).
6. Verified each unit with `mypy`, `flake8` (project CI settings), and `pytest`.

**Strictness policy:** application projects use strict config (`disallow_untyped_defs = true`, matching the existing `file-cleaners` convention); the numpy/learning repos (`tutorials`, `natural-language-processing`, `deep-learnings`) use a lenient config — mirroring the user's own pre-existing lenient `deep-learnings` setup.

**Commits:** two semantic units per repo on the existing topic branch, local only — *“Introduce mypy type checking”* (config/deps/CI/`run_mypy.sh`) and *“Apply autoflake8/autopep8 and fix flake8 violations”* (source pass). Repos already mypy-enabled got only the second commit.

A separate follow-up fix: `save_dicision_boundary_image` (deep-learnings vol2) didn’t open a fresh matplotlib figure, so it rendered onto the leftover loss-plot figure when the test suite ran in one process — corrupting `img/dicision_boundary.png`. Added `plt.figure()` and restored the curated original PNGs (commit `00ed73c`).

## 3. How (Operation and Maintenance)

- **Toolchain:** Windows had no usable Python; the toolchain (Python 3.14, mypy 2.0, flake8, autopep8, autoflake8, pytest) runs under **WSL Ubuntu**. Run all checks there against `/mnt/c/...`.
- **Run type checks:** single-unit projects — `mypy .` from the project dir. `coding-tests` — `bash run_mypy.sh` from `python/` (iterates the 5 subprojects). `deep-learnings` — `bash run_mypy.sh vol1|vol2` from repo root (root `pyproject.toml` config applies); `vol3` is checked per-chapter (intentionally reused module basenames, same reason pytest uses `--import-mode=importlib`).
- **Lint maintenance:** re-run the mandated `autoflake8`/`autopep8` pair, then `flake8 . --max-complexity=10 --max-line-length=127`.
- **CI:** `mypy` jobs are now active in the workflows; pushing the topic branches will exercise them on GitHub.
- **Caveat for maintainers:** several deep-learnings tests `savefig` directly into the tracked `img/` directory, so a full test run rewrites those committed PNGs (now correctly, after the figure fix). Consider redirecting test image output to a temp/untracked path.

## 4. Pros & Cons

### Pros

- Static type safety now enforced in CI across all projects; many latent bugs surfaced and fixed.
- Consistent, convention-compliant formatting; clean `flake8`/`mypy`/`pytest` across the board.
- Per-repo, semantically split commits make review and selective reverts easy.
- Pragmatic per-domain strictness keeps numpy/learning code maintainable without low-value churn.

### Cons & Trade-offs

- A few targeted `# type: ignore` for genuine pre-existing oddities (e.g. `list - dict_keys` valid only via `Set.__rsub__`); not full type purity.
- Type annotations and `autopep8` reflow are interleaved in the same files, so the two semantic commits split at the infra-vs-source boundary rather than purely "types vs lint".
- `autopep8 --aggressive --aggressive` produced some visually awkward wrapping (e.g. multi-line f-strings) — functional but not hand-tuned.
- `deep-learnings/vol2/train/` & `vol2/evaluate/` are pre-existing broken, non-tested experiment scripts — excluded from mypy rather than rewritten.

## 5. Others

- **Skipped:** `github-wiki-organisers-wiki` (the project is a git submodule of the `.wiki` repo — editing it would be wrong).
- **Nothing pushed** — all commits are local on the `hayat01sh1da/python/install-type-checking` topic branch in each repo, per request.
- **Pre-existing, out-of-scope issue flagged:** `natural-language-processing/.github/workflows/1_prereqiosotes.yml` has inconsistent path filters/filename (`vol1/**` vs `1_prerequisites`); left unchanged.
- **Environment-dependent tests:** `web-scrapers` (chromedriver) and `calculator_cli_app` (`CALCULATION_API`) passed in the WSL env but depend on external setup in CI.
- **Verification results:** all units green — e.g. github-wiki-organisers (mypy 14, pytest 32), web-scrapers (mypy 17, pytest 8), coding-tests (pytest 200/2/80/3/4), deep-learnings (mypy 42/108/all-chapters, pytest 48/153/15).