### PR TITLE
[ruby] Update Gem Dependencies

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -2,8 +2,8 @@
 
 source 'https://rubygems.org'
 
-gem 'rbs-inline', '~> 0.13.0', require: false
-gem 'rubocop', '~> 1.86.1', require: false
+gem 'rbs-inline', '~> 0.14.0', require: false
+gem 'rubocop', '~> 1.86.2', require: false
 gem 'rubocop-minitest', '~> 0.39.1', require: false
 gem 'rubocop-performance', '~> 1.26.1', require: false
 gem 'steep', '~> 2.0.0', require: false

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -38,11 +38,11 @@ GEM
       logger
       prism (>= 1.6.0)
       tsort
-    rbs-inline (0.13.0)
+    rbs-inline (0.14.0)
       prism (>= 0.29)
-      rbs (>= 3.8.0)
+      rbs (~> 4.0)
     regexp_parser (2.12.0)
-    rubocop (1.86.1)
+    rubocop (1.86.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -105,8 +105,8 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  rbs-inline (~> 0.13.0)
-  rubocop (~> 1.86.1)
+  rbs-inline (~> 0.14.0)
+  rubocop (~> 1.86.2)
   rubocop-minitest (~> 0.39.1)
   rubocop-performance (~> 1.26.1)
   steep (~> 2.0.0)
@@ -141,9 +141,9 @@ CHECKSUMS
   rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
   rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
   rbs (4.0.2) sha256=af75671e66cd03434cc546622741ebf83f6197ec4328375805306330bf78ef25
-  rbs-inline (0.13.0) sha256=aba6e48c2d1b75276e8557376164f4b4ba96dd0204e779a5cee2af442bd30442
+  rbs-inline (0.14.0) sha256=eaf47b46690d63acddab1f6804c9cc205a4bc78e637cfc421a0b1239874ef51c
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
-  rubocop (1.86.1) sha256=44415f3f01d01a21e01132248d2fd0867572475b566ca188a0a42133a08d4531
+  rubocop (1.86.2) sha256=bb2e97f635eda42c448f2588f4a6ff78f221b8bdfdf65b1e9b07fbd57521b45d
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   rubocop-minitest (0.39.1) sha256=998398d6da4026d297f0f9bf709a1eac5f2b6947c24431f94af08138510cf7ed
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834


### PR DESCRIPTION
## 1. Overview

This is the smallest of the three PRs. It touches only the **`ruby/`** directory and only two declared development gems.  
Notably, `rbs` itself was **already at 4.0.2** in this lockfile, so this PR is just the follow-up that realigns `rbs-inline` to the RBS 4 line and applies a RuboCop patch.

Legend — **Kind**: `patch` = bug-fix only, `minor` = backward-compatible
features, `major` = breaking changes.

## 2. `ruby/` directory

| Gem | Before | After | Kind | Notes |
|---|---|---|---|---|
| rbs-inline | 0.13.0 | 0.14.0 | minor | Dependency requirement changed from `rbs (>= 3.8.0)` to `rbs (~> 4.0)`; locks the inline-RBS tool to the already-present RBS 4.x. |
| rubocop | 1.86.1 | 1.86.2 | patch | Bug-fix release. |

Unchanged but relevant context (no version change, only constraint coupling):

- `rbs` stays at **4.0.2** (already on the v4 line; `prism (>= 1.6.0)` is
  already a dependency).
- `rubocop-minitest (0.39.1)`, `rubocop-performance (1.26.1)` and
  `steep (2.0.0)` are unchanged.

## 3. Summary

- **No major upgrades** in this PR — the heavy RBS 3 → 4 / Steep 1 → 2 migration had already landed in this repo previously.
- One **minor** bump (`rbs-inline` 0.13 → 0.14, tightening it to `rbs ~> 4.0`) and one **patch** bump (`rubocop` 1.86.1 → 1.86.2).
- No gems added or removed.