### PR TITLE
[ruby] Resolve All Violations against Convention reported by RuboCop

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -14,7 +14,11 @@ Metrics/ClassLength:
   CountAsOne: ['array', 'hash', 'method_call']
 
 # Test helpers inline long markdown fixtures, which naturally produces
-# long methods.
+# long methods and long lines.
 Metrics/MethodLength:
+  Exclude:
+    - 'test/**/*'
+
+Layout/LineLength:
   Exclude:
     - 'test/**/*'

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -12,3 +12,9 @@ AllCops:
 
 Metrics/ClassLength:
   CountAsOne: ['array', 'hash', 'method_call']
+
+# Test helpers inline long markdown fixtures, which naturally produces
+# long methods.
+Metrics/MethodLength:
+  Exclude:
+    - 'test/**/*'

--- a/ruby/.rubocop_todo.yml
+++ b/ruby/.rubocop_todo.yml
@@ -6,11 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 17
-# Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
-Metrics/MethodLength:
-  Max: 36
-
 # Offense count: 7
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, AllowRBSInlineAnnotation, AllowCopDirectives, AllowedPatterns, SplitStrings.

--- a/ruby/.rubocop_todo.yml
+++ b/ruby/.rubocop_todo.yml
@@ -11,20 +11,10 @@
 Metrics/AbcSize:
   Max: 51
 
-# Offense count: 2
-# Configuration parameters: AllowedMethods, AllowedPatterns.
-Metrics/CyclomaticComplexity:
-  Max: 8
-
 # Offense count: 17
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
 Metrics/MethodLength:
   Max: 36
-
-# Offense count: 1
-# Configuration parameters: AllowedMethods, AllowedPatterns.
-Metrics/PerceivedComplexity:
-  Max: 9
 
 # Offense count: 7
 # This cop supports safe autocorrection (--autocorrect).

--- a/ruby/.rubocop_todo.yml
+++ b/ruby/.rubocop_todo.yml
@@ -6,11 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 4
-# Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
-Metrics/AbcSize:
-  Max: 51
-
 # Offense count: 17
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
 Metrics/MethodLength:

--- a/ruby/.rubocop_todo.yml
+++ b/ruby/.rubocop_todo.yml
@@ -26,18 +26,6 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Max: 9
 
-# Offense count: 5
-# Configuration parameters: AllowedConstants.
-Style/Documentation:
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
-    - 'src/application.rb'
-    - 'src/home.rb'
-    - 'src/sidebar.rb'
-    - 'src/unknown_wiki_count_list_exporter.rb'
-    - 'src/unknown_wiki_list_exporter_for_llm.rb'
-
 # Offense count: 3
 Style/MultilineBlockChain:
   Exclude:

--- a/ruby/.rubocop_todo.yml
+++ b/ruby/.rubocop_todo.yml
@@ -26,12 +26,6 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Max: 9
 
-# Offense count: 3
-Style/MultilineBlockChain:
-  Exclude:
-    - 'src/unknown_wiki_count_list_exporter.rb'
-    - 'src/unknown_wiki_list_exporter_for_llm.rb'
-
 # Offense count: 7
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, AllowRBSInlineAnnotation, AllowCopDirectives, AllowedPatterns, SplitStrings.

--- a/ruby/.rubocop_todo.yml
+++ b/ruby/.rubocop_todo.yml
@@ -6,55 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 5
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, IndentOneStep, IndentationWidth.
-# SupportedStyles: case, end
-Layout/CaseIndentation:
-  Exclude:
-    - 'src/application.rb'
-
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-Layout/ElseAlignment:
-  Exclude:
-    - 'src/application.rb'
-
-# Offense count: 3
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyleAlignWith.
-# SupportedStylesAlignWith: keyword, variable, start_of_line
-Layout/EndAlignment:
-  Exclude:
-    - 'src/application.rb'
-
-# Offense count: 4
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: Width, EnforcedStyleAlignWith, AllowedPatterns.
-# SupportedStylesAlignWith: start_of_line, relative_to_receiver
-Layout/IndentationWidth:
-  Exclude:
-    - 'src/application.rb'
-
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-Layout/SpaceAfterComma:
-  Exclude:
-    - 'src/home.rb'
-
-# Offense count: 4
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Lint/NonAtomicFileOperation:
-  Exclude:
-    - 'src/home.rb'
-    - 'test/application_test.rb'
-
-# Offense count: 3
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Lint/RedundantDirGlobSort:
-  Exclude:
-    - 'src/application.rb'
-
 # Offense count: 4
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
@@ -75,29 +26,6 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Max: 9
 
-# Offense count: 3
-# This cop supports safe autocorrection (--autocorrect).
-Performance/StringReplacement:
-  Exclude:
-    - 'src/home.rb'
-    - 'src/sidebar.rb'
-
-# Offense count: 11
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, AllowedMethods, AllowedPatterns, AllowBracesOnProceduralOneLiners, BracesRequiredMethods.
-# SupportedStyles: line_count_based, semantic, braces_for_chaining, always_braces
-# ProceduralMethods: benchmark, bm, bmbm, create, each_with_object, measure, new, realtime, tap, with_object
-# FunctionalMethods: let, let!, subject, watch
-# AllowedMethods: lambda, proc, it
-Style/BlockDelimiters:
-  Exclude:
-    - 'src/application.rb'
-    - 'src/home.rb'
-    - 'src/sidebar.rb'
-    - 'src/unknown_wiki_count_list_exporter.rb'
-    - 'src/unknown_wiki_list_exporter_for_llm.rb'
-    - 'test/application_test.rb'
-
 # Offense count: 5
 # Configuration parameters: AllowedConstants.
 Style/Documentation:
@@ -110,90 +38,11 @@ Style/Documentation:
     - 'src/unknown_wiki_count_list_exporter.rb'
     - 'src/unknown_wiki_list_exporter_for_llm.rb'
 
-# Offense count: 10
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: always, always_true, never
-Style/FrozenStringLiteralComment:
-  Exclude:
-    - '**/*.arb'
-    - 'src/application.rb'
-    - 'src/home.rb'
-    - 'src/sidebar.rb'
-    - 'src/unknown_wiki_count_list_exporter.rb'
-    - 'src/unknown_wiki_list_exporter_for_llm.rb'
-    - 'test/application_test.rb'
-    - 'test/home_test.rb'
-    - 'test/sidebar_test.rb'
-    - 'test/unknown_wiki_count_list_exporter_test.rb'
-    - 'test/unknown_wiki_list_exporter_for_llm_test.rb'
-
-# Offense count: 2
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Style/HashSlice:
-  Exclude:
-    - 'src/unknown_wiki_count_list_exporter.rb'
-    - 'src/unknown_wiki_list_exporter_for_llm.rb'
-
 # Offense count: 3
 Style/MultilineBlockChain:
   Exclude:
     - 'src/unknown_wiki_count_list_exporter.rb'
     - 'src/unknown_wiki_list_exporter_for_llm.rb'
-
-# Offense count: 8
-# This cop supports safe autocorrection (--autocorrect).
-Style/RedundantCurrentDirectoryInPath:
-  Exclude:
-    - 'src/home.rb'
-    - 'src/sidebar.rb'
-    - 'src/unknown_wiki_count_list_exporter.rb'
-    - 'src/unknown_wiki_list_exporter_for_llm.rb'
-    - 'test/home_test.rb'
-    - 'test/sidebar_test.rb'
-    - 'test/unknown_wiki_count_list_exporter_test.rb'
-    - 'test/unknown_wiki_list_exporter_for_llm_test.rb'
-
-# Offense count: 9
-# This cop supports safe autocorrection (--autocorrect).
-Style/RedundantRegexpArgument:
-  Exclude:
-    - 'src/home.rb'
-    - 'src/sidebar.rb'
-
-# Offense count: 3
-# This cop supports safe autocorrection (--autocorrect).
-Style/RedundantRegexpEscape:
-  Exclude:
-    - 'src/home.rb'
-    - 'src/sidebar.rb'
-
-# Offense count: 7
-# This cop supports safe autocorrection (--autocorrect).
-Style/SuperArguments:
-  Exclude:
-    - 'src/home.rb'
-    - 'src/unknown_wiki_count_list_exporter.rb'
-    - 'src/unknown_wiki_list_exporter_for_llm.rb'
-    - 'test/home_test.rb'
-    - 'test/sidebar_test.rb'
-    - 'test/unknown_wiki_count_list_exporter_test.rb'
-    - 'test/unknown_wiki_list_exporter_for_llm_test.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, diff_comma, no_comma
-Style/TrailingCommaInHashLiteral:
-  Exclude:
-    - 'test/unknown_wiki_count_list_exporter_test.rb'
-
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: MinSize, WordRegex.
-# SupportedStyles: percent, brackets
-Style/WordArray:
-  EnforcedStyle: brackets
 
 # Offense count: 7
 # This cop supports safe autocorrection (--autocorrect).

--- a/ruby/.rubocop_todo.yml
+++ b/ruby/.rubocop_todo.yml
@@ -6,9 +6,3 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 7
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, AllowRBSInlineAnnotation, AllowCopDirectives, AllowedPatterns, SplitStrings.
-# URISchemes: http, https
-Layout/LineLength:
-  Max: 163

--- a/ruby/sig/generated/src/application.rbs
+++ b/ruby/sig/generated/src/application.rbs
@@ -1,8 +1,15 @@
 # Generated from src/application.rb with RBS::Inline
 
+# Base class for the wiki-organising commands. Loads the wiki tree under
+# base_path, groups it by Owner or Category in either English or Japanese, and
+# exposes the resulting maps to its subclasses.
 class Application
   class NotImplementedError < StandardError
   end
+
+  NO_DECLARATION: untyped
+
+  TARGET_REGEXP: untyped
 
   # @rbs base_path: String
   # @rbs group_by: String
@@ -44,6 +51,10 @@ class Application
 
   attr_reader paths_to_wikis: untyped
 
+  # @rbs raw: String
+  # @rbs return: (bool | String)
+  def parse_home_overflow: (String raw) -> (bool | String)
+
   # @rbs return: Array[String]
   def target_paths: () -> Array[String]
 
@@ -57,6 +68,16 @@ class Application
   # @rbs hash: Hash[String, Array[untyped]]
   # @rbs return: Hash[String, Array[String]]
   def wiki_maps_with_namespace: (?Array[untyped] array, ?Hash[String, Array[untyped]] hash) -> Hash[String, Array[String]]
+
+  # @rbs target_path: String
+  # @rbs hash: Hash[String, Array[String]]
+  # @rbs uncategorised: Hash[String, Array[String]]
+  # @rbs return: void
+  def populate_namespace: (String target_path, Hash[String, Array[String]] hash, Hash[String, Array[String]] uncategorised) -> void
+
+  # @rbs file: File
+  # @rbs return: String
+  def namespace_for: (File file) -> String
 
   # @rbs return: Hash[String, Array[String]]
   def owned_wiki_maps: () -> Hash[String, Array[String]]

--- a/ruby/sig/generated/src/home.rbs
+++ b/ruby/sig/generated/src/home.rbs
@@ -1,5 +1,7 @@
 # Generated from src/home.rb with RBS::Inline
 
+# Generates the wiki Home page, optionally splitting per-owner content out into
+# `wikis-by-owner/<owner>.md` when home_overflow is enabled.
 class Home < Application
   HOME_URL: untyped
 
@@ -31,4 +33,30 @@ class Home < Application
   # @rbs array: Array[untyped]
   # @rbs return: void
   def write_concise_home_passage: (?Array[untyped] array) -> void
+
+  # @rbs array: Array[untyped]
+  # @rbs return: void
+  def write_per_namespace_files: (Array[untyped] array) -> void
+
+  # @rbs return: void
+  def write_home_table_of_contents: () -> void
+
+  # @rbs passage: Array[String]
+  # @rbs namespace: String
+  # @rbs wikis: Array[String]
+  # @rbs owned: bool
+  # @rbs return: void
+  def append_block: (Array[String] passage, String namespace, Array[String] wikis, owned: bool) -> void
+
+  # @rbs namespace: String
+  # @rbs wikis: Array[String]
+  # @rbs scratch: Array[String]
+  # @rbs owned: bool
+  # @rbs return: void
+  def write_overflow_block: (String namespace, Array[String] wikis, Array[String] scratch, owned: bool) -> void
+
+  # @rbs namespace: String
+  # @rbs owned: bool
+  # @rbs return: String
+  def heading_for: (String namespace, owned: bool) -> String
 end

--- a/ruby/sig/generated/src/sidebar.rbs
+++ b/ruby/sig/generated/src/sidebar.rbs
@@ -1,5 +1,7 @@
 # Generated from src/sidebar.rb with RBS::Inline
 
+# Generates the wiki _Sidebar.md as a nested list of owners/categories and
+# their wiki pages.
 class Sidebar < Application
   # @rbs base_path: String
   # @rbs group_by: String
@@ -20,4 +22,15 @@ class Sidebar < Application
 
   # @rbs return: void
   def update_wiki_list: () -> void
+
+  # @rbs namespace: String
+  # @rbs wikis: Array[String]
+  # @rbs owned: bool
+  # @rbs return: void
+  def append_section: (String namespace, Array[String] wikis, owned: bool) -> void
+
+  # @rbs namespace: String
+  # @rbs owned: bool
+  # @rbs return: String
+  def section_heading: (String namespace, owned: bool) -> String
 end

--- a/ruby/sig/generated/src/unknown_wiki_count_list_exporter.rbs
+++ b/ruby/sig/generated/src/unknown_wiki_count_list_exporter.rbs
@@ -1,6 +1,10 @@
 # Generated from src/unknown_wiki_count_list_exporter.rb with RBS::Inline
 
+# Writes a sorted text report of how many wikis exist under each of the
+# well-known "unknown owner/category" namespaces.
 class UnknownWikiCountListExporter < Application
+  NAMESPACE_LIST: untyped
+
   # @rbs base_path: String
   # @rbs group_by: String
   # @rbs language: String

--- a/ruby/sig/generated/src/unknown_wiki_list_exporter_for_llm.rbs
+++ b/ruby/sig/generated/src/unknown_wiki_list_exporter_for_llm.rbs
@@ -1,6 +1,10 @@
 # Generated from src/unknown_wiki_list_exporter_for_llm.rb with RBS::Inline
 
+# Writes a flat list of the wikis under the "unknown owner/category" namespace
+# in a form suitable for feeding to an LLM.
 class UnknownWikiListExporterForLLM < Application
+  TARGET_NAMESPACE: untyped
+
   # @rbs base_path: String
   # @rbs group_by: String
   # @rbs language: String

--- a/ruby/src/application.rb
+++ b/ruby/src/application.rb
@@ -8,14 +8,14 @@ class Application
   class NotImplementedError < StandardError; end
 
   NO_DECLARATION = {
-    %w[Owner English]     => 'Unowned',
-    %w[Owner Japanese]    => 'Owner記名なし',
-    %w[Category English]  => 'Uncategorised',
+    %w[Owner English] => 'Unowned',
+    %w[Owner Japanese] => 'Owner記名なし',
+    %w[Category English] => 'Uncategorised',
     %w[Category Japanese] => 'Category記載なし'
   }.freeze
 
   TARGET_REGEXP = {
-    'Owner'    => /[Oo]wner:\s?/,
+    'Owner' => /[Oo]wner:\s?/,
     'Category' => /[Cc]ategory:\s?/
   }.freeze
 

--- a/ruby/src/application.rb
+++ b/ruby/src/application.rb
@@ -7,6 +7,18 @@
 class Application
   class NotImplementedError < StandardError; end
 
+  NO_DECLARATION = {
+    %w[Owner English]     => 'Unowned',
+    %w[Owner Japanese]    => 'Owner記名なし',
+    %w[Category English]  => 'Uncategorised',
+    %w[Category Japanese] => 'Category記載なし'
+  }.freeze
+
+  TARGET_REGEXP = {
+    'Owner'    => /[Oo]wner:\s?/,
+    'Category' => /[Cc]ategory:\s?/
+  }.freeze
+
   # @rbs base_path: String
   # @rbs group_by: String
   # @rbs language: String
@@ -27,14 +39,7 @@ class Application
     @base_path     = base_path
     @group_by      = group_by
     @language      = language
-    @home_overflow = case home_overflow
-                     when 'true'
-                       true
-                     when 'false'
-                       false
-                     else
-                       home_overflow
-                     end
+    @home_overflow = parse_home_overflow(home_overflow)
     @path_to_home                   = File.join(base_path, 'Home.md')
     @path_to_sidebar                = File.join(base_path, '_Sidebar.md')
     @path_to_github_wiki_organisers = Dir[File.join(base_path, 'github-wiki-organisers', '**', '*.md')]
@@ -46,7 +51,10 @@ class Application
   def validate!
     raise ArgumentError, "Invalid group_by: `#{group_by}`" unless %w[Owner Category].include?(group_by)
     raise ArgumentError, "Invalid language: `#{language}`" unless %w[English Japanese].include?(language)
-    raise ArgumentError, "Invalid home_overflow: `#{home_overflow}` must be boolean" unless [true, false].include?(home_overflow)
+
+    return if [true, false].include?(home_overflow)
+
+    raise ArgumentError, "Invalid home_overflow: `#{home_overflow}` must be boolean"
   end
 
   # @rbs return: void
@@ -66,6 +74,16 @@ class Application
               :path_to_wikis_by_owner,
               :paths_to_wikis
 
+  # @rbs raw: String
+  # @rbs return: (bool | String)
+  def parse_home_overflow(raw)
+    case raw
+    when 'true'  then true
+    when 'false' then false
+    else raw
+    end
+  end
+
   # @rbs return: Array[String]
   def target_paths
     @target_paths ||= paths_to_wikis.delete_if do |path_to_wiki|
@@ -78,65 +96,48 @@ class Application
 
   # @rbs return: Regexp
   def target_regexp
-    @target_regexp ||= case group_by
-                       when 'Owner'
-                         /[Oo]wner:\s?/
-                       when 'Category'
-                         /[Cc]ategory:\s?/
-                       else
-                         //
-                       end
+    @target_regexp ||= TARGET_REGEXP.fetch(group_by, //)
   end
 
   # @rbs return: String
   def no_declaration
-    @no_declaration ||= case group_by
-                        when 'Owner'
-                          case language
-                          when 'English'
-                            'Unowned'
-                          when 'Japanese'
-                            'Owner記名なし'
-                          else
-                            ''
-                          end
-                        when 'Category'
-                          case language
-                          when 'English'
-                            'Uncategorised'
-                          when 'Japanese'
-                            'Category記載なし'
-                          else
-                            ''
-                          end
-                        else
-                          ''
-                        end
+    @no_declaration ||= NO_DECLARATION.fetch([group_by, language], '')
   end
 
   # @rbs array: Array[untyped]
   # @rbs hash: Hash[String, Array[untyped]]
   # @rbs return: Hash[String, Array[String]]
-  def wiki_maps_with_namespace(array = [], hash = Hash.new { |hash, namespace| hash[namespace] = array.dup })
-    uncategrised_wiki_maps = hash
+  def wiki_maps_with_namespace(array = [], hash = Hash.new { |h, namespace| h[namespace] = array.dup })
+    uncategorised = hash
 
-    @wiki_maps_with_namespace ||= target_paths.each.with_object(hash.dup) do |target_path, hash|
-      next unless File.exist?(target_path)
+    @wiki_maps_with_namespace ||= target_paths.each.with_object(hash.dup) do |target_path, acc|
+      populate_namespace(target_path, acc, uncategorised)
+    end.sort.to_h.merge(uncategorised)
+  end
 
-      File.open(target_path) do |file|
-        wiki = File.basename(file)
+  # @rbs target_path: String
+  # @rbs hash: Hash[String, Array[String]]
+  # @rbs uncategorised: Hash[String, Array[String]]
+  # @rbs return: void
+  def populate_namespace(target_path, hash, uncategorised)
+    return unless File.exist?(target_path)
 
-        namespace_declaration = file.readlines.first
-        namespace             = if namespace_declaration&.start_with?(target_regexp)
-                                  namespace_declaration.chomp.gsub(target_regexp, '')
-                                else
-                                  no_declaration
-                                end
+    File.open(target_path) do |file|
+      wiki      = File.basename(file)
+      namespace = namespace_for(file)
 
-        hash[namespace] << wiki unless namespace == no_declaration
-        uncategrised_wiki_maps[namespace] << wiki if namespace == no_declaration
-      end
-    end.sort.to_h.merge(uncategrised_wiki_maps)
+      target = namespace == no_declaration ? uncategorised : hash
+      target[namespace] << wiki
+    end
+  end
+
+  # @rbs file: File
+  # @rbs return: String
+  def namespace_for(file)
+    declaration = file.readlines.first
+    return no_declaration unless declaration&.start_with?(target_regexp)
+
+    declaration.chomp.gsub(target_regexp, '')
   end
 
   # @rbs return: Hash[String, Array[String]]

--- a/ruby/src/application.rb
+++ b/ruby/src/application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
 class Application
@@ -25,23 +26,23 @@ class Application
     @language      = language
     @home_overflow = case home_overflow
                      when 'true'
-                      true
-                      when 'false'
-                      false
+                       true
+                     when 'false'
+                       false
                      else
                        home_overflow
                      end
     @path_to_home                   = File.join(base_path, 'Home.md')
     @path_to_sidebar                = File.join(base_path, '_Sidebar.md')
-    @path_to_github_wiki_organisers = Dir[File.join(base_path, 'github-wiki-organisers', '**', '*.md')].sort
-    @path_to_wikis_by_owner         = Dir[File.join(base_path, 'wikis-by-owner', '*.md')].sort
-    @paths_to_wikis                 = Dir[File.join(base_path, '**', '*.md')].sort
+    @path_to_github_wiki_organisers = Dir[File.join(base_path, 'github-wiki-organisers', '**', '*.md')]
+    @path_to_wikis_by_owner         = Dir[File.join(base_path, 'wikis-by-owner', '*.md')]
+    @paths_to_wikis                 = Dir[File.join(base_path, '**', '*.md')]
   end
 
   # @rbs return: void
   def validate!
-    raise ArgumentError, "Invalid group_by: `#{group_by}`" unless ['Owner', 'Category'].include?(group_by)
-    raise ArgumentError, "Invalid language: `#{language}`" unless ['English', 'Japanese'].include?(language)
+    raise ArgumentError, "Invalid group_by: `#{group_by}`" unless %w[Owner Category].include?(group_by)
+    raise ArgumentError, "Invalid language: `#{language}`" unless %w[English Japanese].include?(language)
     raise ArgumentError, "Invalid home_overflow: `#{home_overflow}` must be boolean" unless [true, false].include?(home_overflow)
   end
 
@@ -64,50 +65,50 @@ class Application
 
   # @rbs return: Array[String]
   def target_paths
-    @target_paths ||= paths_to_wikis.delete_if { |path_to_wiki|
+    @target_paths ||= paths_to_wikis.delete_if do |path_to_wiki|
       path_to_wiki == path_to_home ||
         path_to_wiki == path_to_sidebar ||
         path_to_github_wiki_organisers.include?(path_to_wiki) ||
         path_to_wikis_by_owner.include?(path_to_wiki)
-    }
+    end
   end
 
   # @rbs return: Regexp
   def target_regexp
     @target_regexp ||= case group_by
-    when 'Owner'
-      /[Oo]wner:\s?/
-    when 'Category'
-      /[Cc]ategory:\s?/
-    else
-      //
-    end
+                       when 'Owner'
+                         /[Oo]wner:\s?/
+                       when 'Category'
+                         /[Cc]ategory:\s?/
+                       else
+                         //
+                       end
   end
 
   # @rbs return: String
   def no_declaration
     @no_declaration ||= case group_by
-    when 'Owner'
-      case language
-      when 'English'
-        'Unowned'
-      when 'Japanese'
-        'Owner記名なし'
-      else
-        ''
-      end
-    when 'Category'
-      case language
-      when 'English'
-        'Uncategorised'
-      when 'Japanese'
-        'Category記載なし'
-      else
-        ''
-      end
-    else
-      ''
-    end
+                        when 'Owner'
+                          case language
+                          when 'English'
+                            'Unowned'
+                          when 'Japanese'
+                            'Owner記名なし'
+                          else
+                            ''
+                          end
+                        when 'Category'
+                          case language
+                          when 'English'
+                            'Uncategorised'
+                          when 'Japanese'
+                            'Category記載なし'
+                          else
+                            ''
+                          end
+                        else
+                          ''
+                        end
   end
 
   # @rbs array: Array[untyped]
@@ -116,23 +117,23 @@ class Application
   def wiki_maps_with_namespace(array = [], hash = Hash.new { |hash, namespace| hash[namespace] = array.dup })
     uncategrised_wiki_maps = hash
 
-    @wiki_maps_with_namespace ||= target_paths.each.with_object(hash.dup) { |target_path, hash|
+    @wiki_maps_with_namespace ||= target_paths.each.with_object(hash.dup) do |target_path, hash|
       next unless File.exist?(target_path)
 
-      File.open(target_path) { |file|
+      File.open(target_path) do |file|
         wiki = File.basename(file)
 
         namespace_declaration = file.readlines.first
         namespace             = if namespace_declaration&.start_with?(target_regexp)
-          namespace_declaration.chomp.gsub(target_regexp, '')
-        else
-          no_declaration
-        end
+                                  namespace_declaration.chomp.gsub(target_regexp, '')
+                                else
+                                  no_declaration
+                                end
 
         hash[namespace] << wiki unless namespace == no_declaration
         uncategrised_wiki_maps[namespace] << wiki if namespace == no_declaration
-      }
-    }.sort.to_h.merge(uncategrised_wiki_maps)
+      end
+    end.sort.to_h.merge(uncategrised_wiki_maps)
   end
 
   # @rbs return: Hash[String, Array[String]]

--- a/ruby/src/application.rb
+++ b/ruby/src/application.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 # rbs_inline: enabled
 
+# Base class for the wiki-organising commands. Loads the wiki tree under
+# base_path, groups it by Owner or Category in either English or Japanese, and
+# exposes the resulting maps to its subclasses.
 class Application
   class NotImplementedError < StandardError; end
 

--- a/ruby/src/home.rb
+++ b/ruby/src/home.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
-require_relative './application'
+require_relative 'application'
 
 class Home < Application
   HOME_URL = "https://github.com/#{ENV.fetch('ORGANISATION_NAME', 'hayat01sh1da')}/github-wiki-organisers/wiki".freeze
@@ -11,7 +12,7 @@ class Home < Application
   # @rbs home_overflow: String
   # @rbs return: void
   def initialize(base_path: '', group_by: '', language: '', home_overflow: 'false')
-    super(base_path:, group_by:, language:, home_overflow:)
+    super
     @base_owner_url         = "https://github.com/orgs/#{ENV.fetch('ORGANISATION_NAME', 'hayat01sh1da')}/teams/"
     @path_to_wikis_by_owner = File.join(base_path, 'wikis-by-owner')
   end
@@ -43,25 +44,25 @@ class Home < Application
 
   # @rbs return: void
   def write_home_passage
-    FileUtils.rm_rf(path_to_wikis_by_owner) if Dir.exist?(path_to_wikis_by_owner)
+    FileUtils.rm_rf(path_to_wikis_by_owner)
 
-    owned_wiki_maps.each { |namespace, wikis|
-      home_passage << "## [#{namespace}](#{base_owner_url + namespace.gsub(/\@/, '')})\n"
+    owned_wiki_maps.each do |namespace, wikis|
+      home_passage << "## [#{namespace}](#{base_owner_url + namespace.delete('@')})\n"
       home_passage << "\n"
-      wikis.each { |wiki|
-        home_passage << "- [[#{wiki.gsub(/\.md/, '')}]]\n"
-      }
+      wikis.each do |wiki|
+        home_passage << "- [[#{wiki.gsub('.md', '')}]]\n"
+      end
       home_passage << "\n"
-    }
+    end
 
-    plain_wiki_maps.each { |namespace, wikis|
+    plain_wiki_maps.each do |namespace, wikis|
       home_passage << "## #{namespace}\n"
       home_passage << "\n"
-      wikis.each { |wiki|
-        home_passage << "- [[#{wiki.gsub(/\.md/, '')}]]\n"
-      }
+      wikis.each do |wiki|
+        home_passage << "- [[#{wiki.gsub('.md', '')}]]\n"
+      end
       home_passage << "\n"
-    }
+    end
 
     File.write(path_to_home, home_passage.join.chomp)
   end
@@ -69,31 +70,31 @@ class Home < Application
   # @rbs array: Array[untyped]
   # @rbs return: void
   def write_concise_home_passage(array = [])
-    FileUtils.mkdir_p(path_to_wikis_by_owner) unless Dir.exist?(path_to_wikis_by_owner)
+    FileUtils.mkdir_p(path_to_wikis_by_owner)
 
-    owned_wiki_maps.each { |namespace, wikis|
+    owned_wiki_maps.each do |namespace, wikis|
       home_passage  = array
-      home_passage << "## [#{namespace}](#{base_owner_url + namespace.gsub(/\@/, '')})\n"
+      home_passage << "## [#{namespace}](#{base_owner_url + namespace.delete('@')})\n"
       home_passage << "\n"
-      wikis.each { |wiki|
-        home_passage << "- [[#{wiki.gsub(/\.md/, '')}]]\n"
-      }
+      wikis.each do |wiki|
+        home_passage << "- [[#{wiki.gsub('.md', '')}]]\n"
+      end
       home_passage << "\n"
 
-      File.write(File.join(path_to_wikis_by_owner,"#{namespace}.md"), home_passage.join.chomp)
-    }
+      File.write(File.join(path_to_wikis_by_owner, "#{namespace}.md"), home_passage.join.chomp)
+    end
 
-    plain_wiki_maps.each { |namespace, wikis|
+    plain_wiki_maps.each do |namespace, wikis|
       home_passage  = array.dup
       home_passage << "## #{namespace}\n"
       home_passage << "\n"
-      wikis.each { |wiki|
-        home_passage << "- [[#{wiki.gsub(/\.md/, '')}]]\n"
-      }
+      wikis.each do |wiki|
+        home_passage << "- [[#{wiki.gsub('.md', '')}]]\n"
+      end
       home_passage << "\n"
 
-      File.write(File.join(path_to_wikis_by_owner,"#{namespace}.md"), home_passage.join.chomp)
-    }
+      File.write(File.join(path_to_wikis_by_owner, "#{namespace}.md"), home_passage.join.chomp)
+    end
 
     (owned_wiki_maps.keys + plain_wiki_maps.keys).each { |namespace| home_passage << "- [[#{namespace}]]\n" }
     home_passage << "\n"

--- a/ruby/src/home.rb
+++ b/ruby/src/home.rb
@@ -21,12 +21,7 @@ class Home < Application
 
   # @rbs return: String
   def run
-    if home_overflow
-      write_concise_home_passage
-    else
-      write_home_passage
-    end
-
+    home_overflow ? write_concise_home_passage : write_home_passage
     HOME_URL
   end
 
@@ -47,25 +42,8 @@ class Home < Application
   # @rbs return: void
   def write_home_passage
     FileUtils.rm_rf(path_to_wikis_by_owner)
-
-    owned_wiki_maps.each do |namespace, wikis|
-      home_passage << "## [#{namespace}](#{base_owner_url + namespace.delete('@')})\n"
-      home_passage << "\n"
-      wikis.each do |wiki|
-        home_passage << "- [[#{wiki.gsub('.md', '')}]]\n"
-      end
-      home_passage << "\n"
-    end
-
-    plain_wiki_maps.each do |namespace, wikis|
-      home_passage << "## #{namespace}\n"
-      home_passage << "\n"
-      wikis.each do |wiki|
-        home_passage << "- [[#{wiki.gsub('.md', '')}]]\n"
-      end
-      home_passage << "\n"
-    end
-
+    owned_wiki_maps.each { |namespace, wikis| append_block(home_passage, namespace, wikis, owned: true) }
+    plain_wiki_maps.each { |namespace, wikis| append_block(home_passage, namespace, wikis, owned: false) }
     File.write(path_to_home, home_passage.join.chomp)
   end
 
@@ -73,33 +51,50 @@ class Home < Application
   # @rbs return: void
   def write_concise_home_passage(array = [])
     FileUtils.mkdir_p(path_to_wikis_by_owner)
+    write_per_namespace_files(array)
+    write_home_table_of_contents
+  end
 
-    owned_wiki_maps.each do |namespace, wikis|
-      home_passage  = array
-      home_passage << "## [#{namespace}](#{base_owner_url + namespace.delete('@')})\n"
-      home_passage << "\n"
-      wikis.each do |wiki|
-        home_passage << "- [[#{wiki.gsub('.md', '')}]]\n"
-      end
-      home_passage << "\n"
+  # @rbs array: Array[untyped]
+  # @rbs return: void
+  def write_per_namespace_files(array)
+    owned_wiki_maps.each { |namespace, wikis| write_overflow_block(namespace, wikis, array, owned: true) }
+    plain_wiki_maps.each { |namespace, wikis| write_overflow_block(namespace, wikis, array.dup, owned: false) }
+  end
 
-      File.write(File.join(path_to_wikis_by_owner, "#{namespace}.md"), home_passage.join.chomp)
-    end
-
-    plain_wiki_maps.each do |namespace, wikis|
-      home_passage  = array.dup
-      home_passage << "## #{namespace}\n"
-      home_passage << "\n"
-      wikis.each do |wiki|
-        home_passage << "- [[#{wiki.gsub('.md', '')}]]\n"
-      end
-      home_passage << "\n"
-
-      File.write(File.join(path_to_wikis_by_owner, "#{namespace}.md"), home_passage.join.chomp)
-    end
-
+  # @rbs return: void
+  def write_home_table_of_contents
     (owned_wiki_maps.keys + plain_wiki_maps.keys).each { |namespace| home_passage << "- [[#{namespace}]]\n" }
     home_passage << "\n"
     File.write(path_to_home, home_passage.join.chomp)
+  end
+
+  # @rbs passage: Array[String]
+  # @rbs namespace: String
+  # @rbs wikis: Array[String]
+  # @rbs owned: bool
+  # @rbs return: void
+  def append_block(passage, namespace, wikis, owned:)
+    passage << "#{heading_for(namespace, owned:)}\n"
+    passage << "\n"
+    wikis.each { |wiki| passage << "- [[#{wiki.gsub('.md', '')}]]\n" }
+    passage << "\n"
+  end
+
+  # @rbs namespace: String
+  # @rbs wikis: Array[String]
+  # @rbs scratch: Array[String]
+  # @rbs owned: bool
+  # @rbs return: void
+  def write_overflow_block(namespace, wikis, scratch, owned:)
+    append_block(scratch, namespace, wikis, owned:)
+    File.write(File.join(path_to_wikis_by_owner, "#{namespace}.md"), scratch.join.chomp)
+  end
+
+  # @rbs namespace: String
+  # @rbs owned: bool
+  # @rbs return: String
+  def heading_for(namespace, owned:)
+    owned ? "## [#{namespace}](#{base_owner_url + namespace.delete('@')})" : "## #{namespace}"
   end
 end

--- a/ruby/src/home.rb
+++ b/ruby/src/home.rb
@@ -3,6 +3,8 @@
 
 require_relative 'application'
 
+# Generates the wiki Home page, optionally splitting per-owner content out into
+# `wikis-by-owner/<owner>.md` when home_overflow is enabled.
 class Home < Application
   HOME_URL = "https://github.com/#{ENV.fetch('ORGANISATION_NAME', 'hayat01sh1da')}/github-wiki-organisers/wiki".freeze
 

--- a/ruby/src/sidebar.rb
+++ b/ruby/src/sidebar.rb
@@ -3,6 +3,8 @@
 
 require_relative 'application'
 
+# Generates the wiki _Sidebar.md as a nested list of owners/categories and
+# their wiki pages.
 class Sidebar < Application
   # @rbs base_path: String
   # @rbs group_by: String

--- a/ruby/src/sidebar.rb
+++ b/ruby/src/sidebar.rb
@@ -30,18 +30,23 @@ class Sidebar < Application
 
   # @rbs return: void
   def update_wiki_list
-    owned_wiki_maps.each do |namespace, wikis|
-      wiki_list << "- [#{namespace}](#{base_owner_url + namespace.delete('@')})\n"
-      wikis.each do |wiki|
-        wiki_list << "  - [[#{wiki.gsub('.md', '')}]]\n"
-      end
-    end
+    owned_wiki_maps.each { |namespace, wikis| append_section(namespace, wikis, owned: true) }
+    plain_wiki_maps.each { |namespace, wikis| append_section(namespace, wikis, owned: false) }
+  end
 
-    plain_wiki_maps.each do |namespace, wikis|
-      wiki_list << "- #{namespace}\n"
-      wikis.each do |wiki|
-        wiki_list << "  - [[#{wiki.gsub('.md', '')}]]\n"
-      end
-    end
+  # @rbs namespace: String
+  # @rbs wikis: Array[String]
+  # @rbs owned: bool
+  # @rbs return: void
+  def append_section(namespace, wikis, owned:)
+    wiki_list << "#{section_heading(namespace, owned:)}\n"
+    wikis.each { |wiki| wiki_list << "  - [[#{wiki.gsub('.md', '')}]]\n" }
+  end
+
+  # @rbs namespace: String
+  # @rbs owned: bool
+  # @rbs return: String
+  def section_heading(namespace, owned:)
+    owned ? "- [#{namespace}](#{base_owner_url + namespace.delete('@')})" : "- #{namespace}"
   end
 end

--- a/ruby/src/sidebar.rb
+++ b/ruby/src/sidebar.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
-require_relative './application'
+require_relative 'application'
 
 class Sidebar < Application
   # @rbs base_path: String
@@ -27,18 +28,18 @@ class Sidebar < Application
 
   # @rbs return: void
   def update_wiki_list
-    owned_wiki_maps.each { |namespace, wikis|
-      wiki_list << "- [#{namespace}](#{base_owner_url + namespace.gsub(/\@/, '')})\n"
-      wikis.each { |wiki|
-        wiki_list << "  - [[#{wiki.gsub(/\.md/, '')}]]\n"
-      }
-    }
+    owned_wiki_maps.each do |namespace, wikis|
+      wiki_list << "- [#{namespace}](#{base_owner_url + namespace.delete('@')})\n"
+      wikis.each do |wiki|
+        wiki_list << "  - [[#{wiki.gsub('.md', '')}]]\n"
+      end
+    end
 
-    plain_wiki_maps.each { |namespace, wikis|
+    plain_wiki_maps.each do |namespace, wikis|
       wiki_list << "- #{namespace}\n"
-      wikis.each { |wiki|
-        wiki_list << "  - [[#{wiki.gsub(/\.md/, '')}]]\n"
-      }
-    }
+      wikis.each do |wiki|
+        wiki_list << "  - [[#{wiki.gsub('.md', '')}]]\n"
+      end
+    end
   end
 end

--- a/ruby/src/unknown_wiki_count_list_exporter.rb
+++ b/ruby/src/unknown_wiki_count_list_exporter.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
-require_relative './application'
+require_relative 'application'
 
 class UnknownWikiCountListExporter < Application
   # @rbs base_path: String
@@ -9,7 +10,7 @@ class UnknownWikiCountListExporter < Application
   # @rbs home_overflow: String
   # @rbs return: void
   def initialize(base_path: '', group_by: '', language: '', home_overflow: 'false')
-    super(base_path:, group_by:, language:, home_overflow:)
+    super
     @path_to_export = File.join(base_path, 'unknown_wiki_count_list_by_namespace.txt')
   end
 
@@ -68,12 +69,10 @@ class UnknownWikiCountListExporter < Application
 
   # @rbs return: Array[String]
   def count_list_by_namespace
-    @count_list_by_namespace ||= plain_wiki_maps.select { |namespace, _|
-      namespace_list.include?(namespace)
-    }.map { |namespace, wikis|
+    @count_list_by_namespace ||= plain_wiki_maps.slice(*namespace_list).map do |namespace, wikis|
       "#{namespace}: #{wikis.length}"
-    }.then { |list_by_namespace|
+    end.then do |list_by_namespace|
       list_by_namespace + missing_count_list_by_namespace
-    }.sort
+    end.sort
   end
 end

--- a/ruby/src/unknown_wiki_count_list_exporter.rb
+++ b/ruby/src/unknown_wiki_count_list_exporter.rb
@@ -71,10 +71,9 @@ class UnknownWikiCountListExporter < Application
 
   # @rbs return: Array[String]
   def count_list_by_namespace
-    @count_list_by_namespace ||= plain_wiki_maps.slice(*namespace_list).map do |namespace, wikis|
-      "#{namespace}: #{wikis.length}"
-    end.then do |list_by_namespace|
-      list_by_namespace + missing_count_list_by_namespace
-    end.sort
+    @count_list_by_namespace ||= begin
+      counts = plain_wiki_maps.slice(*namespace_list).map { |namespace, wikis| "#{namespace}: #{wikis.length}" }
+      (counts + missing_count_list_by_namespace).sort
+    end
   end
 end

--- a/ruby/src/unknown_wiki_count_list_exporter.rb
+++ b/ruby/src/unknown_wiki_count_list_exporter.rb
@@ -6,6 +6,13 @@ require_relative 'application'
 # Writes a sorted text report of how many wikis exist under each of the
 # well-known "unknown owner/category" namespaces.
 class UnknownWikiCountListExporter < Application
+  NAMESPACE_LIST = {
+    %w[Owner English]     => ['Unknown Owner nor Necessity', 'Unowned but Necessary', 'Unowned'],
+    %w[Owner Japanese]    => ['Ownerチームが不明だが必要なページ群', 'Ownerチーム・要or不要が不明なページ群', 'Owner記名なし'],
+    %w[Category English]  => ['Uncategorised'],
+    %w[Category Japanese] => ['Category記載なし']
+  }.freeze
+
   # @rbs base_path: String
   # @rbs group_by: String
   # @rbs language: String
@@ -28,40 +35,7 @@ class UnknownWikiCountListExporter < Application
 
   # @rbs return: Array[String]
   def namespace_list
-    case group_by
-    when 'Owner'
-      case language
-      when 'English'
-        [
-          'Unknown Owner nor Necessity',
-          'Unowned but Necessary',
-          'Unowned'
-        ]
-      when 'Japanese'
-        [
-          'Ownerチームが不明だが必要なページ群',
-          'Ownerチーム・要or不要が不明なページ群',
-          'Owner記名なし'
-        ]
-      else
-        ['']
-      end
-    when 'Category'
-      case language
-      when 'English'
-        [
-          'Uncategorised'
-        ]
-      when 'Japanese'
-        [
-          'Category記載なし'
-        ]
-      else
-        ['']
-      end
-    else
-      ['']
-    end
+    NAMESPACE_LIST.fetch([group_by, language], [''])
   end
 
   # @rbs return: Array[String]

--- a/ruby/src/unknown_wiki_count_list_exporter.rb
+++ b/ruby/src/unknown_wiki_count_list_exporter.rb
@@ -3,6 +3,8 @@
 
 require_relative 'application'
 
+# Writes a sorted text report of how many wikis exist under each of the
+# well-known "unknown owner/category" namespaces.
 class UnknownWikiCountListExporter < Application
   # @rbs base_path: String
   # @rbs group_by: String

--- a/ruby/src/unknown_wiki_count_list_exporter.rb
+++ b/ruby/src/unknown_wiki_count_list_exporter.rb
@@ -7,9 +7,9 @@ require_relative 'application'
 # well-known "unknown owner/category" namespaces.
 class UnknownWikiCountListExporter < Application
   NAMESPACE_LIST = {
-    %w[Owner English]     => ['Unknown Owner nor Necessity', 'Unowned but Necessary', 'Unowned'],
-    %w[Owner Japanese]    => ['Ownerチームが不明だが必要なページ群', 'Ownerチーム・要or不要が不明なページ群', 'Owner記名なし'],
-    %w[Category English]  => ['Uncategorised'],
+    %w[Owner English] => ['Unknown Owner nor Necessity', 'Unowned but Necessary', 'Unowned'],
+    %w[Owner Japanese] => ['Ownerチームが不明だが必要なページ群', 'Ownerチーム・要or不要が不明なページ群', 'Owner記名なし'],
+    %w[Category English] => ['Uncategorised'],
     %w[Category Japanese] => ['Category記載なし']
   }.freeze
 

--- a/ruby/src/unknown_wiki_list_exporter_for_llm.rb
+++ b/ruby/src/unknown_wiki_list_exporter_for_llm.rb
@@ -54,8 +54,6 @@ class UnknownWikiListExporterForLLM < Application
 
   # @rbs return: Array[String]
   def unknown_wiki_list_for_llm
-    @unknown_wiki_list_for_llm ||= plain_wiki_maps.slice(*target_namespace).then do |filtered_plain_wiki_maps|
-      filtered_plain_wiki_maps.values.flatten
-    end
+    @unknown_wiki_list_for_llm ||= plain_wiki_maps.slice(*target_namespace).values.flatten
   end
 end

--- a/ruby/src/unknown_wiki_list_exporter_for_llm.rb
+++ b/ruby/src/unknown_wiki_list_exporter_for_llm.rb
@@ -3,6 +3,8 @@
 
 require_relative 'application'
 
+# Writes a flat list of the wikis under the "unknown owner/category" namespace
+# in a form suitable for feeding to an LLM.
 class UnknownWikiListExporterForLLM < Application
   # @rbs base_path: String
   # @rbs group_by: String

--- a/ruby/src/unknown_wiki_list_exporter_for_llm.rb
+++ b/ruby/src/unknown_wiki_list_exporter_for_llm.rb
@@ -6,6 +6,13 @@ require_relative 'application'
 # Writes a flat list of the wikis under the "unknown owner/category" namespace
 # in a form suitable for feeding to an LLM.
 class UnknownWikiListExporterForLLM < Application
+  TARGET_NAMESPACE = {
+    %w[Owner English]     => 'Unknown Owner nor Necessity',
+    %w[Owner Japanese]    => 'Ownerチーム・要or不要が不明なページ群',
+    %w[Category English]  => 'Uncategorised',
+    %w[Category Japanese] => 'Category記載なし'
+  }.freeze
+
   # @rbs base_path: String
   # @rbs group_by: String
   # @rbs language: String
@@ -28,28 +35,7 @@ class UnknownWikiListExporterForLLM < Application
 
   # @rbs return: String
   def target_namespace
-    case group_by
-    when 'Owner'
-      case language
-      when 'English'
-        'Unknown Owner nor Necessity'
-      when 'Japanese'
-        'Ownerチーム・要or不要が不明なページ群'
-      else
-        ''
-      end
-    when 'Category'
-      case language
-      when 'English'
-        'Uncategorised'
-      when 'Japanese'
-        'Category記載なし'
-      else
-        ''
-      end
-    else
-      ''
-    end
+    TARGET_NAMESPACE.fetch([group_by, language], '')
   end
 
   # @rbs return: Array[String]

--- a/ruby/src/unknown_wiki_list_exporter_for_llm.rb
+++ b/ruby/src/unknown_wiki_list_exporter_for_llm.rb
@@ -40,6 +40,6 @@ class UnknownWikiListExporterForLLM < Application
 
   # @rbs return: Array[String]
   def unknown_wiki_list_for_llm
-    @unknown_wiki_list_for_llm ||= plain_wiki_maps.slice(*target_namespace).values.flatten
+    @unknown_wiki_list_for_llm ||= plain_wiki_maps.slice(target_namespace).values.flatten
   end
 end

--- a/ruby/src/unknown_wiki_list_exporter_for_llm.rb
+++ b/ruby/src/unknown_wiki_list_exporter_for_llm.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
-require_relative './application'
+require_relative 'application'
 
 class UnknownWikiListExporterForLLM < Application
   # @rbs base_path: String
@@ -9,7 +10,7 @@ class UnknownWikiListExporterForLLM < Application
   # @rbs home_overflow: String
   # @rbs return: void
   def initialize(base_path: '', group_by: '', language: '', home_overflow: 'false')
-    super(base_path:, group_by:, language:, home_overflow:)
+    super
     @path_to_export = File.join(base_path, 'unknown_wiki_list_for_llm.txt')
   end
 
@@ -51,10 +52,8 @@ class UnknownWikiListExporterForLLM < Application
 
   # @rbs return: Array[String]
   def unknown_wiki_list_for_llm
-    @unknown_wiki_list_for_llm ||= plain_wiki_maps.select { |namespace, _|
-      target_namespace.include?(namespace)
-    }.then { |filtered_plain_wiki_maps|
+    @unknown_wiki_list_for_llm ||= plain_wiki_maps.slice(*target_namespace).then do |filtered_plain_wiki_maps|
       filtered_plain_wiki_maps.values.flatten
-    }
+    end
   end
 end

--- a/ruby/src/unknown_wiki_list_exporter_for_llm.rb
+++ b/ruby/src/unknown_wiki_list_exporter_for_llm.rb
@@ -7,9 +7,9 @@ require_relative 'application'
 # in a form suitable for feeding to an LLM.
 class UnknownWikiListExporterForLLM < Application
   TARGET_NAMESPACE = {
-    %w[Owner English]     => 'Unknown Owner nor Necessity',
-    %w[Owner Japanese]    => 'Ownerチーム・要or不要が不明なページ群',
-    %w[Category English]  => 'Uncategorised',
+    %w[Owner English] => 'Unknown Owner nor Necessity',
+    %w[Owner Japanese] => 'Ownerチーム・要or不要が不明なページ群',
+    %w[Category English] => 'Uncategorised',
     %w[Category Japanese] => 'Category記載なし'
   }.freeze
 

--- a/ruby/test/application_test.rb
+++ b/ruby/test/application_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
 require 'minitest/autorun'
@@ -9,14 +10,14 @@ class ApplicationTest < Minitest::Test
     @group_by      = group_by
     @language      = language
     @home_overflow = home_overflow
-    FileUtils.mkdir_p(base_path) unless Dir.exist?(base_path)
-    test_file_maps.each { |wiki, namespace|
+    FileUtils.mkdir_p(base_path)
+    test_file_maps.each do |wiki, namespace|
       File.write(File.join(base_path, wiki), namespace)
-    }
+    end
   end
 
   def teardown
-    FileUtils.rm_rf(base_path) if Dir.exist?(base_path)
+    FileUtils.rm_rf(base_path)
   end
 
   def test_validate_group_by!

--- a/ruby/test/home_test.rb
+++ b/ruby/test/home_test.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
-require_relative './application_test'
+require_relative 'application_test'
 require_relative '../src/home'
 
 class HomeTest < ApplicationTest
   def setup(group_by: 'Owner', language: 'English', home_overflow: false)
-    super(group_by:, language:, home_overflow:)
+    super
     Home.run(base_path:, group_by:, language:, home_overflow:)
     @path_to_home           = File.join(base_path, 'Home.md')
     @home                   = File.read(path_to_home)

--- a/ruby/test/sidebar_test.rb
+++ b/ruby/test/sidebar_test.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
-require_relative './application_test'
+require_relative 'application_test'
 require_relative '../src/sidebar'
 
 class SidebarTest < ApplicationTest
   def setup(group_by: 'Owner', language: 'English')
-    super(group_by:, language:)
+    super
     Sidebar.run(base_path:, group_by:, language:)
     @path_to_sidebar = File.join(base_path, '_Sidebar.md')
     @sidebar         = File.read(path_to_sidebar)

--- a/ruby/test/unknown_wiki_count_list_exporter_test.rb
+++ b/ruby/test/unknown_wiki_count_list_exporter_test.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
-require_relative './application_test'
+require_relative 'application_test'
 require_relative '../src/unknown_wiki_count_list_exporter'
 
 class UnknownWikiCountListExporterTest < ApplicationTest
   def setup(group_by: 'Owner', language: 'English')
-    super(group_by:, language:)
+    super
     UnknownWikiCountListExporter.run(base_path:, group_by:, language:)
     @path_to_unknown_wiki_count_list = File.join(base_path, 'unknown_wiki_count_list_by_namespace.txt')
     @unknown_wiki_count_list         = File.read(path_to_unknown_wiki_count_list)
@@ -294,7 +295,7 @@ class UnknownWikiCountListExporterTest < ApplicationTest
           {
             'Owner記名ありページ.md' => 'Owner: @test-owner',
             'Ownerチームが不明だが必要なページ.md' => 'Owner: Ownerチームが不明だが必要なページ群',
-            'Ownerチーム・要or不要が不明なページ.md' => 'Owner: Ownerチーム・要or不要が不明なページ群',
+            'Ownerチーム・要or不要が不明なページ.md' => 'Owner: Ownerチーム・要or不要が不明なページ群'
           }
         end
       end

--- a/ruby/test/unknown_wiki_list_exporter_for_llm_test.rb
+++ b/ruby/test/unknown_wiki_list_exporter_for_llm_test.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
-require_relative './application_test'
+require_relative 'application_test'
 require_relative '../src/unknown_wiki_list_exporter_for_llm'
 
 class UnknownWikiListExporterForLLMTest < ApplicationTest
   def setup(group_by: 'Owner', language: 'English')
-    super(group_by:, language:)
+    super
     UnknownWikiListExporterForLLM.run(base_path:, group_by:, language:)
     @path_to_unknown_wiki_list_for_llm = File.join(base_path, 'unknown_wiki_list_for_llm.txt')
     @unknown_wiki_list_for_llm         = File.read(path_to_unknown_wiki_list_for_llm)


### PR DESCRIPTION
## 1. Summary

Resolve all violations against Ruby convention reported by RuboCop listed on `rubocop_todo.yml`.

## 2. Commits

- [Resolve autocorrectable RuboCop violations](https://github.com/hayat01sh1da/github-wiki-organisers/pull/69/commits/31788adeaf281a4fc632a8e6804425e6224adc03)
- [esolve Style/Documentation](https://github.com/hayat01sh1da/github-wiki-organisers/pull/69/commits/ffbc96f34998e2be51e49f1ff10e8d65ccd79dde)
- [Resolve Style/MultilineBlockChain](https://github.com/hayat01sh1da/github-wiki-organisers/pull/69/commits/846bb607dd11665a2a8caf437ebb51c477ae12ab)
- [Resolve Metrics/CyclomaticComplexity and Metrics/PerceivedComplexity](https://github.com/hayat01sh1da/github-wiki-organisers/pull/69/commits/096189a54522fb1ff29557e69eee49ae0f178055)
- [Resolve Metrics/AbcSize](https://github.com/hayat01sh1da/github-wiki-organisers/pull/69/commits/aae5389b7e97f8823a58ffa8473ddd6bac5772bb)
- [Resolve Metrics/MethodLength](https://github.com/hayat01sh1da/github-wiki-organisers/pull/69/commits/8e5c119bbb1298e136ea0eb4e0a690849ba95195)
- [Resolve Layout/LineLength and Layout/HashAlignment](https://github.com/hayat01sh1da/github-wiki-organisers/pull/69/commits/2ef9ab9b10ac53ecfc1c48aa7059ebbc2f8738e2)[Update RBS signature files](https://github.com/hayat01sh1da/github-wiki-organisers/pull/69/commits/b4e4c7d0cdca90969555a2f59f4167601f14d286)
- [Fix typecheck error](https://github.com/hayat01sh1da/github-wiki-organisers/pull/69/commits/d0b6ddc25d8aa7ab794319d5edc9951b8a9e759b)