### PR TITLE
[ruby] Update Gem Dependencies

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'rbs-inline', '~> 0.14.0', require: false
-gem 'rubocop', '~> 1.86.2', require: false
+gem 'rubocop', '~> 1.88.0', require: false
 gem 'rubocop-minitest', '~> 0.39.1', require: false
 gem 'rubocop-performance', '~> 1.26.1', require: false
 gem 'steep', '~> 2.0.0', require: false

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (4.0.2)
+    rbs (4.0.3)
       logger
       prism (>= 1.6.0)
       tsort
@@ -42,7 +42,7 @@ GEM
       prism (>= 0.29)
       rbs (~> 4.0)
     regexp_parser (2.12.0)
-    rubocop (1.86.2)
+    rubocop (1.88.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -106,7 +106,7 @@ PLATFORMS
 
 DEPENDENCIES
   rbs-inline (~> 0.14.0)
-  rubocop (~> 1.86.2)
+  rubocop (~> 1.88.0)
   rubocop-minitest (~> 0.39.1)
   rubocop-performance (~> 1.26.1)
   steep (~> 2.0.0)
@@ -140,10 +140,10 @@ CHECKSUMS
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
   rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
-  rbs (4.0.2) sha256=af75671e66cd03434cc546622741ebf83f6197ec4328375805306330bf78ef25
+  rbs (4.0.3) sha256=5a7bf70e2628549d9a1f44eae447b2cfe55968a9c60cfff52693a4bdcc020e14
   rbs-inline (0.14.0) sha256=eaf47b46690d63acddab1f6804c9cc205a4bc78e637cfc421a0b1239874ef51c
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
-  rubocop (1.86.2) sha256=bb2e97f635eda42c448f2588f4a6ff78f221b8bdfdf65b1e9b07fbd57521b45d
+  rubocop (1.88.0) sha256=e420ddf1662d0ef34bc8a2910ac4b396a7ddda0b51a708264405241734b08e0b
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   rubocop-minitest (0.39.1) sha256=998398d6da4026d297f0f9bf709a1eac5f2b6947c24431f94af08138510cf7ed
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834


### PR DESCRIPTION
## 1. Overview

This PR ([#107](https://github.com/hayat01sh1da/coding-tests/pull/107)) updates the Gem dependencies of the `ruby/` project in the `coding-tests` repository.  
It is a small, focused update that bumps a single directly declared gem (`rubocop`) in `Gemfile` and one transitively locked gem (`rbs`) in `Gemfile.lock`.  
Both are in-major-version bumps, so no breaking changes are expected.

## 2. Key Changes & Differences in Each Gem

|Gems |Before |After |Changes & Differences |
|:-|:-|:-|:-|
| rubocop | 1.86.2 | 1.88.0 | Directly declared linter in `ruby/Gemfile` (`gem 'rubocop', '~> 1.88.0'`). Minor bump adding new cops and bug fixes. |
| rbs | 4.0.2 | 4.0.3 | Transitive (locked) type-signature dependency pulled in via `rbs-inline` / `steep`. Patch release. |

## 3. Summary

This is a minimal maintenance update.  
The only directly requested change is `rubocop` 1.86.2 → 1.88.0, with `rbs` 4.0.3 resolved transitively by Bundler.  
The other RuboCop plugins (`rubocop-minitest`, `rubocop-performance`) and `steep` were left untouched and remain compatible with the new RuboCop version.  
The change is confined to the development/lint/type-checking toolchain and carries minimal risk.

## 4. References

- [RuboCop CHANGELOG](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md)
- [rbs releases](https://github.com/ruby/rbs/releases)
- [Pull Request #107](https://github.com/hayat01sh1da/coding-tests/pull/107/changes)