### PR TITLE
[ruby] Update Gem Dependencies

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
     fileutils (1.8.0)
-    json (2.19.9)
+    json (2.20.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     listen (3.10.0)
@@ -128,7 +128,7 @@ CHECKSUMS
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
   fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
-  json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
+  json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2


### PR DESCRIPTION
## 1. Overview

This pull request updates a locked gem dependency.  
It is a routine, low-risk maintenance update that bumps a single transitive gem to its latest minor release in the `Gemfile.lock`.  
No application code or top-level `Gemfile` constraints were changed; only the resolved version (and its checksum) in the lockfile was modified.

## 2. Key Changes & Differences in Each Gem

|Gems |Before |After |Changes & Differences |
|:-|:-|:-|:-|
| json | 2.19.9 | 2.20.0 | C and Java parsers reworked to be non-recursive, removing "stack level too deep" errors on deeply nested documents (even with `max_nesting: false`). Float parsing switched from ryu to an Eisel-Lemire Fast Float port for speed. Adds `JSON::ResumableParser` for parsing JSON document streams (not yet on JRuby) and Ruby 4.1 `ruby_sized_xfree` support. JavaScript comment support is now deprecated unless `allow_comments: true` is set; `:max_nesting` still defaults to 100. |

## 3. Summary

This is a single, backwards-compatible minor bump of the `json` gem with no breaking changes expected for normal usage.  
`json 2.20.0` brings a non-recursive parser, faster float parsing, and a new streaming parser; the main thing to watch is the deprecation of implicit JavaScript-comment parsing.  
Merging is recommended; standard test-suite verification is sufficient.

## 4. References

- [json gem CHANGES](https://github.com/ruby/json/blob/master/CHANGES.md)
- [json gem releases](https://github.com/ruby/json/releases)