### PR TITLE
[ruby] Update Gem Dependencies

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'rbs-inline', '~> 0.14.0', require: false
-gem 'rubocop', '~> 1.88.0', require: false
+gem 'rubocop', '~> 1.88.1', require: false
 gem 'rubocop-minitest', '~> 0.39.1', require: false
 gem 'rubocop-performance', '~> 1.26.1', require: false
 gem 'steep', '~> 2.0.0', require: false

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
       prism (>= 0.29)
       rbs (~> 4.0)
     regexp_parser (2.12.0)
-    rubocop (1.88.0)
+    rubocop (1.88.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -106,7 +106,7 @@ PLATFORMS
 
 DEPENDENCIES
   rbs-inline (~> 0.14.0)
-  rubocop (~> 1.88.0)
+  rubocop (~> 1.88.1)
   rubocop-minitest (~> 0.39.1)
   rubocop-performance (~> 1.26.1)
   steep (~> 2.0.0)
@@ -143,7 +143,7 @@ CHECKSUMS
   rbs (4.0.3) sha256=5a7bf70e2628549d9a1f44eae447b2cfe55968a9c60cfff52693a4bdcc020e14
   rbs-inline (0.14.0) sha256=eaf47b46690d63acddab1f6804c9cc205a4bc78e637cfc421a0b1239874ef51c
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
-  rubocop (1.88.0) sha256=e420ddf1662d0ef34bc8a2910ac4b396a7ddda0b51a708264405241734b08e0b
+  rubocop (1.88.1) sha256=726af773d6bc169ed3ff852f3ca020b7c58d39c34e7a8d879a8e0147cc994f26
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   rubocop-minitest (0.39.1) sha256=998398d6da4026d297f0f9bf709a1eac5f2b6947c24431f94af08138510cf7ed
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834


### PR DESCRIPTION
## 1. Overview

This branch performs routine maintenance of the standalone Ruby project's gem dependencies.
It updates the RuboCop development tool in `ruby/Gemfile` and `ruby/Gemfile.lock`.
This is a dev-only tooling change; no runtime code is affected.

## 2. Key Changes & Differences

| Gems      | Before | After  | Changes & Differences                                                                  |
| :-------- | :----- | :----- | :------------------------------------------------------------------------------------- |
| `rubocop` | 1.88.0 | 1.88.1 | Patch bump. Constraint `~> 1.88.0` → `~> 1.88.1`; locked version and checksum updated. |

## 3. Summary

`rubocop` is bumped from **1.88.0** to **1.88.1**. This is a low-risk, dependency-only change affecting linting tooling, with no functional impact on the codebase.

## 4. References

- [RuboCop v1.88.1 release notes](https://github.com/rubocop/rubocop/releases/tag/v1.88.1)
- [rubocop on RubyGems](https://rubygems.org/gems/rubocop/versions/1.88.1)