### PR TITLE
[ruby] Update Gem Dependencies

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     ffi (1.17.4-x86_64-linux-musl)
     fileutils (1.8.0)
     json (2.20.0)
-    language_server-protocol (3.17.0.5)
+    language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     listen (3.10.0)
       logger
@@ -53,7 +53,7 @@ GEM
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.1)
+    rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     rubocop-minitest (0.39.1)
@@ -129,7 +129,7 @@ CHECKSUMS
   ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
   fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
   json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
-  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
@@ -144,7 +144,7 @@ CHECKSUMS
   rbs-inline (0.14.0) sha256=eaf47b46690d63acddab1f6804c9cc205a4bc78e637cfc421a0b1239874ef51c
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   rubocop (1.88.1) sha256=726af773d6bc169ed3ff852f3ca020b7c58d39c34e7a8d879a8e0147cc994f26
-  rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
   rubocop-minitest (0.39.1) sha256=998398d6da4026d297f0f9bf709a1eac5f2b6947c24431f94af08138510cf7ed
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33


### PR DESCRIPTION
## 1. Overview

This topic branch carries out routine dependency maintenance for the Ruby subproject (`ruby/`)
of this repository. It was cut from `master` and contains a single commit: `31d4561 Update gem dependencies`.

The update refreshes two gems of the RuboCop static-analysis toolchain to their latest releases:
`language_server-protocol` 3.17.0.5 → 3.17.0.6 and `rubocop-ast` 1.49.1 → 1.50.0. Both are
transitive dependencies resolved via the `rubocop` family pinned in the `Gemfile`, so the only
file that changes is `ruby/Gemfile.lock` — each gem's version pin together with its `CHECKSUMS`
(SHA-256) entry.

## 2. Key Changes & Differences

|Gems |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|`language_server-protocol`  |`3.17.0.5` |`3.17.0.6` |Patch-level update. Ruby interface definitions for the Language Server Protocol, used by RuboCop's built-in LSP server. Transitive dependency of `rubocop` — the `Gemfile` is unchanged; only the lockfile pin and its `CHECKSUMS` (SHA-256) entry move. |
|`rubocop-ast`  |`1.49.1` |`1.50.0` |Minor-level update. RuboCop's abstract-syntax-tree and node-pattern layer, with new node APIs and fixes. Resolved transitively from the pinned `rubocop` family, so no `Gemfile` change is required. |

## 3. Summary

This is a low-risk, development-tooling-only change: neither updated gem ships runtime code for
the project — both support the RuboCop linting toolchain. No application code or `Gemfile`
constraints change, and both bumps are backwards-compatible (patch and minor respectively).
Suggested verification before merge: `bundle install`, then run the linters/type checkers
(`bundle exec rubocop`, and `bundle exec steep check` where configured) and the test suite.

## 4. References

- [language_server-protocol on RubyGems](https://rubygems.org/gems/language_server-protocol)
- [language_server-protocol-ruby releases](https://github.com/mtsmfm/language_server-protocol-ruby/releases)
- [rubocop-ast on RubyGems](https://rubygems.org/gems/rubocop-ast)
- [rubocop-ast CHANGELOG](https://github.com/rubocop/rubocop-ast/blob/master/CHANGELOG.md)