### PR TITLE
[github-actions] Modify Configurations of Daily Library Dependencies Update Cron Job

### DIFF
--- a/.github/workflows/python--daily-dependencies-update.yml
+++ b/.github/workflows/python--daily-dependencies-update.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
+          sign-commits: true
           branch: hayat01sh1da/daily/python/update-pip-library-dependencies
           delete-branch: true
           add-paths: |

--- a/.github/workflows/python--daily-dependencies-update.yml
+++ b/.github/workflows/python--daily-dependencies-update.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
-          branch: daily/python-dependency-updates
+          branch: hayat01sh1da/daily/python/update-pip-library-dependencies
           delete-branch: true
           add-paths: |
             python/requirements.txt

--- a/.github/workflows/ruby--daily-dependencies-update.yml
+++ b/.github/workflows/ruby--daily-dependencies-update.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
-          branch: daily/ruby-dependency-updates
+          branch: hayat01sh1da/daily/ruby/update-gem-dependencies
           delete-branch: true
           add-paths: |
             ruby/Gemfile

--- a/.github/workflows/ruby--daily-dependencies-update.yml
+++ b/.github/workflows/ruby--daily-dependencies-update.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           gem update --system
           gem install bundler
+          bundle update --bundler
           bundle update --all
       - name: Mirror Updated Versions to Gemfile
         working-directory: ./ruby
@@ -54,6 +55,7 @@ jobs:
           ~~~console
           gem update --system
           gem install bundler
+          bundle update --bundler
           bundle update --all
           ~~~
 

--- a/.github/workflows/ruby--daily-dependencies-update.yml
+++ b/.github/workflows/ruby--daily-dependencies-update.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
+          sign-commits: true
           branch: hayat01sh1da/daily/ruby/update-gem-dependencies
           delete-branch: true
           add-paths: |


### PR DESCRIPTION
## 1. Overview

This pull request modifies the configurations of the daily library dependencies update cron jobs (Python - Daily Dependencies Update, Ruby - Daily Dependencies Update) so that the automated commits satisfy the *Require signed commits* Default Branch Protection rule.

It makes the following changes:

- Adds `sign-commits: true` to the `peter-evans/create-pull-request@v8` step. The commits opened by the cron job are now created through GitHub's GraphQL API and GPG-signed (RSA) by GitHub as `github-actions[bot]`, so they are marked **Verified**.
- Renames the topic branches used by the cron job from `daily/<language>-dependency-updates` to the `hayat01sh1da/daily/<language>/<summary>` naming convention.
- Adds `bundle update --bundler` before `bundle update --all` so that the `BUNDLED WITH` version recorded in `Gemfile.lock` is kept in sync with the Bundler upgraded by `gem install bundler`.

## 2. Key Changes & Differences

|Workflows |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|Python - Daily Dependencies Update |Pushed commits created by local `git` (unsigned) to `daily/python-dependency-updates` |Pushes GPG-signed **Verified** commits created via the GitHub API to `hayat01sh1da/daily/python/update-pip-library-dependencies` |Added `sign-commits: true` to the `peter-evans/create-pull-request@v8` step so the commits are signed as `github-actions[bot]`, and renamed the topic branch to the `hayat01sh1da/` naming convention |
|Ruby - Daily Dependencies Update |Pushed commits created by local `git` (unsigned) to `daily/ruby-dependency-updates`<br>`gem install bundler` upgraded Bundler, but the `BUNDLED WITH` version in `Gemfile.lock` was left stale |Pushes GPG-signed **Verified** commits created via the GitHub API to `hayat01sh1da/daily/ruby/update-gem-dependencies`<br>Runs `bundle update --bundler` before `bundle update --all` |Added `sign-commits: true` to the `peter-evans/create-pull-request@v8` step so the commits are signed as `github-actions[bot]`, and renamed the topic branch to the `hayat01sh1da/` naming convention<br>Mirrors the updated Bundler version to `Gemfile.lock` |

## 3. Summary

All 2 daily dependencies update cron workflows in this repository now push GPG-signed **Verified** commits to `hayat01sh1da/`-prefixed topic branches, and the Bundler-based workflows also keep the `BUNDLED WITH` version in `Gemfile.lock` up to date.
The new configuration takes effect from the next scheduled run at 0:00 JST; no further action is required after merging.
Please make sure that all CI workflows pass before merging this pull request.

## 4. References

- [.github/workflows/python--daily-dependencies-update.yml](https://github.com/hayat01sh1da/github-wiki-organisers/blob/hayat01sh1da/github-actions/modify-configurations-of-daily-library-dependencies-update-cron-job/.github/workflows/python--daily-dependencies-update.yml)
- [.github/workflows/ruby--daily-dependencies-update.yml](https://github.com/hayat01sh1da/github-wiki-organisers/blob/hayat01sh1da/github-actions/modify-configurations-of-daily-library-dependencies-update-cron-job/.github/workflows/ruby--daily-dependencies-update.yml)
- [peter-evans/create-pull-request — `sign-commits` input](https://github.com/peter-evans/create-pull-request)
- [About commit signature verification — GitHub Docs](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
- [About protected branches: Require signed commits — GitHub Docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-signed-commits)
- [bundle update — Bundler Docs](https://bundler.io/man/bundle-update.1.html)
