### PR TITLE
[github-actions] Refine Dependency Report Script

### DIFF
--- a/.github/scripts/dependency_report.sh
+++ b/.github/scripts/dependency_report.sh
@@ -12,9 +12,12 @@
 # Parses `git diff` of the lockfile and prints a markdown table describing each
 # changed dependency: the semver level of the change, the package's summary
 # fetched from its registry (PyPI / RubyGems / npm), and whether it is a direct
-# or transitive dependency. Package-manager updates are reported too: pip as a
-# regular requirements.lock entry, bundler from the lockfile's BUNDLED WITH
-# section, and pnpm from the manifest's packageManager field.
+# or transitive dependency. Each dependency name links to its page on the
+# official registry (https://rubygems.org / https://pypi.org /
+# https://www.npmjs.com) so reviewers can check release notes and changelogs.
+# Package-manager updates are reported too: pip as a regular requirements.lock
+# entry, bundler from the lockfile's BUNDLED WITH section, and pnpm from the
+# manifest's packageManager field.
 set -euo pipefail
 
 ecosystem=$1
@@ -176,9 +179,14 @@ while IFS= read -r name; do
     kind='Transitive dependency.'
   fi
   notes="${what}. ${description:+$description }${kind}"
+  case $ecosystem in
+    pip) registry_url="https://pypi.org/project/${normalised}/" ;;
+    gem) registry_url="https://rubygems.org/gems/${name}" ;;
+    *)   registry_url="https://www.npmjs.com/package/${name}" ;;
+  esac
   old_cell=${old:+\`$old\`}
   new_cell=${new:+\`$new\`}
-  rows+="|\`${name}\` |${old_cell:--} |${new_cell:--} |${notes} |"$'\n'
+  rows+="|[\`${name}\`](${registry_url}) |${old_cell:--} |${new_cell:--} |${notes} |"$'\n'
 done < <(printf '%s\n' "${!before[@]}" "${!after[@]}" | sort -fu)
 
 echo "|${label} |Before |After |Changes & Differences |"

--- a/.github/workflows/python--daily-dependencies-update.yml
+++ b/.github/workflows/python--daily-dependencies-update.yml
@@ -76,6 +76,8 @@ jobs:
           - [PyPI](https://pypi.org/)
           SUMMARY
           } > "$BODY_PATH"
+      - name: Compute Timestamp
+        run: echo "TIMESTAMP=$(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M:%S JST')" >> "$GITHUB_ENV"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
@@ -85,7 +87,7 @@ jobs:
           add-paths: |
             python/requirements.txt
             python/requirements.lock
-          commit-message: "[Daily][Python] Update pip Library Dependencies"
+          commit-message: "[Daily][Python] Update PyPI library dependencies at ${{ env.TIMESTAMP }}"
           title: "[Daily][Python] Update PyPI Library Dependencies"
           body-path: ${{ runner.temp }}/pr_body.md
           reviewers: hayat01sh1da

--- a/.github/workflows/python--daily-dependencies-update.yml
+++ b/.github/workflows/python--daily-dependencies-update.yml
@@ -80,7 +80,7 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           sign-commits: true
-          branch: hayat01sh1da/daily/python/update-pip-library-dependencies
+          branch: hayat01sh1da/daily/python/update-pypi-library-dependencies
           delete-branch: true
           add-paths: |
             python/requirements.txt

--- a/.github/workflows/python--daily-dependencies-update.yml
+++ b/.github/workflows/python--daily-dependencies-update.yml
@@ -73,6 +73,7 @@ jobs:
 
           - [Python - Daily Dependencies Update workflow run](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)
           - [pip install documentation](https://pip.pypa.io/en/stable/cli/pip_install/)
+          - [PyPI](https://pypi.org/)
           SUMMARY
           } > "$BODY_PATH"
       - name: Create Pull Request

--- a/.github/workflows/python--daily-dependencies-update.yml
+++ b/.github/workflows/python--daily-dependencies-update.yml
@@ -86,7 +86,7 @@ jobs:
             python/requirements.txt
             python/requirements.lock
           commit-message: "[Daily][Python] Update pip Library Dependencies"
-          title: "[Daily][Python] Update pip Library Dependencies"
+          title: "[Daily][Python] Update PyPI Library Dependencies"
           body-path: ${{ runner.temp }}/pr_body.md
           reviewers: hayat01sh1da
           assignees: hayat01sh1da

--- a/.github/workflows/ruby--daily-dependencies-update.yml
+++ b/.github/workflows/ruby--daily-dependencies-update.yml
@@ -74,6 +74,7 @@ jobs:
 
           - [Ruby - Daily Dependencies Update workflow run](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)
           - [bundle update documentation](https://bundler.io/man/bundle-update.1.html)
+          - [RubyGems](https://rubygems.org/)
           SUMMARY
           } > "$BODY_PATH"
       - name: Create Pull Request

--- a/.github/workflows/ruby--daily-dependencies-update.yml
+++ b/.github/workflows/ruby--daily-dependencies-update.yml
@@ -81,7 +81,7 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           sign-commits: true
-          branch: hayat01sh1da/daily/ruby/update-gem-dependencies
+          branch: hayat01sh1da/daily/ruby/update-rubygems-dependencies
           delete-branch: true
           add-paths: |
             ruby/Gemfile

--- a/.github/workflows/ruby--daily-dependencies-update.yml
+++ b/.github/workflows/ruby--daily-dependencies-update.yml
@@ -77,6 +77,8 @@ jobs:
           - [RubyGems](https://rubygems.org/)
           SUMMARY
           } > "$BODY_PATH"
+      - name: Compute Timestamp
+        run: echo "TIMESTAMP=$(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M:%S JST')" >> "$GITHUB_ENV"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
@@ -86,7 +88,7 @@ jobs:
           add-paths: |
             ruby/Gemfile
             ruby/Gemfile.lock
-          commit-message: "[Daily][Ruby] Update Gem Dependencies"
+          commit-message: "[Daily][Ruby] Update RubyGems dependencies at ${{ env.TIMESTAMP }}"
           title: "[Daily][Ruby] Update RubyGems Dependencies"
           body-path: ${{ runner.temp }}/pr_body.md
           reviewers: hayat01sh1da

--- a/.github/workflows/ruby--daily-dependencies-update.yml
+++ b/.github/workflows/ruby--daily-dependencies-update.yml
@@ -87,7 +87,7 @@ jobs:
             ruby/Gemfile
             ruby/Gemfile.lock
           commit-message: "[Daily][Ruby] Update Gem Dependencies"
-          title: "[Daily][Ruby] Update Gem Dependencies"
+          title: "[Daily][Ruby] Update RubyGems Dependencies"
           body-path: ${{ runner.temp }}/pr_body.md
           reviewers: hayat01sh1da
           assignees: hayat01sh1da


### PR DESCRIPTION
## 1. Overview

This pull request refines the daily library dependencies update automation so that the pull requests it creates refer to the official package registries and carry a JST timestamp in their commit messages.  
Each dependency row in the auto-generated report now links to the package's page on its official registry (RubyGems / PyPI / npm), the workflows' References section links the registry itself, and the daily branch / commit message / PR title wording is aligned with the registry names.

## 2. Key Changes & Differences

|Files |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|`.github/scripts/dependency_report.sh` |Bare dependency names in the generated report table |Each dependency name links to its page on the official registry |Adds a per-ecosystem registry URL (RubyGems / PyPI / npm) to every row of the daily dependency PR table so reviewers can check release notes and changelogs directly. |
|`.github/workflows/python--daily-dependencies-update.yml` |No registry link in References; commit message `[Daily][Python] Update pip Library Dependencies`; daily branch `update-pip-library-dependencies` |References include [PyPI](https://pypi.org/); commit message `[Daily][Python] Update PyPI library dependencies at <JST timestamp>`; daily branch `update-pypi-library-dependencies` |Adds the official PyPI link to § 4 References, introduces a `Compute Timestamp` step (JST) whose value is appended to the commit message, and aligns the daily branch / commit / title wording with the PyPI registry name. |
|`.github/workflows/ruby--daily-dependencies-update.yml` |No registry link in References; commit message `[Daily][Ruby] Update Gem dependencies`; daily branch `update-gem-dependencies` |References include [RubyGems](https://rubygems.org/); commit message `[Daily][Ruby] Update RubyGems dependencies at <JST timestamp>`; daily branch `update-rubygems-dependencies` |Adds the official RubyGems link to § 4 References, introduces a `Compute Timestamp` step (JST) whose value is appended to the commit message, and aligns the daily branch / commit / title wording with the RubyGems registry name. |

## 3. Summary

- 3 files updated: the shared dependency report script and 2 daily dependencies update workflow(s); the dependency-update logic itself is unchanged.  
- The refined report and commit messages take effect from the next scheduled run.  
- Please make sure that all CI workflows pass before merging this pull request.

## 4. References

- [.github/scripts/dependency_report.sh](https://github.com/hayat01sh1da/github-wiki-organisers/blob/hayat01sh1da/github-actions/refine-dependency-report-script/.github/scripts/dependency_report.sh)
- [.github/workflows/python--daily-dependencies-update.yml](https://github.com/hayat01sh1da/github-wiki-organisers/blob/hayat01sh1da/github-actions/refine-dependency-report-script/.github/workflows/python--daily-dependencies-update.yml)
- [.github/workflows/ruby--daily-dependencies-update.yml](https://github.com/hayat01sh1da/github-wiki-organisers/blob/hayat01sh1da/github-actions/refine-dependency-report-script/.github/workflows/ruby--daily-dependencies-update.yml)
- [RubyGems](https://rubygems.org/)
- [PyPI](https://pypi.org/)
