### PR TITLE
[github-actions] Replace ruby/setup with Shared setup-ruby

### DIFF
--- a/.github/workflows/export-unknown-wiki-list-for-llm.yml
+++ b/.github/workflows/export-unknown-wiki-list-for-llm.yml
@@ -49,8 +49,7 @@ jobs:
           path: ./github-wiki-organisers/wiki
       - name: Configure Git Identity
         uses: ./github-wiki-organisers/.github/actions/configure-git-identity
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - uses: ./.github/actions/setup-ruby
       - name: Export Unknown Wiki List for LLM
         working-directory: ./github-wiki-organisers/wiki
         run: |

--- a/.github/workflows/notify-wiki-count-by-namespace.yml
+++ b/.github/workflows/notify-wiki-count-by-namespace.yml
@@ -74,8 +74,7 @@ jobs:
           repository: "${{ github.repository }}.wiki"
           ref: master
           path: .wiki
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - uses: ./.github/actions/setup-ruby
       - name: Format Unknown Wiki Count by Namespace
         id: format
         working-directory: .wiki

--- a/.github/workflows/update-wiki-list-on-home-and-sidebar.yml
+++ b/.github/workflows/update-wiki-list-on-home-and-sidebar.yml
@@ -55,8 +55,7 @@ jobs:
           path: ./github-wiki-organisers/wiki
       - name: Configure Git Identity
         uses: ./github-wiki-organisers/.github/actions/configure-git-identity
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - uses: ./.github/actions/setup-ruby
       - name: Update github-wiki-organisers Wiki
         working-directory: ./github-wiki-organisers/wiki
         run: |


### PR DESCRIPTION
## 1. Overview

I manually ran the following cron jobs and found they failed to setup Ruby.  
They directly invoke `ruby/setup`, but it misses Ruby version definition file because parameter of the path to `.ruby-version`.  
It should be replaced with `actions/setup-ruby` instead.

## 2. Key Changes & Differences

|Package |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|ruby/setup |Directly invoked |Invoked via setup-ruby |All Ruby-related jobs refer to setup-ruby to resolve redundancy |

## 3. Summary

Till this patch was applied, the workflows are verbose, yet it has been resolved.