### PR TITLE
[GitHub Actions] Amend Configurations of Cron Jobs for Wiki

### DIFF
--- a/.github/workflows/export-unknown-wiki-list-for-llm.yml
+++ b/.github/workflows/export-unknown-wiki-list-for-llm.yml
@@ -35,33 +35,44 @@ jobs:
       commit_message: ${{ steps.commit.outputs.commit_message }}
       jst_current_datetime: ${{ steps.commit.outputs.jst_current_datetime }}
     steps:
+      # The main repository must live at the workspace root so that the local
+      # .github/actions/* resolve and ruby/setup-ruby finds .ruby-version.
       - name: Checkout the Main Repository
         uses: actions/checkout@v7
         with:
           repository: "${{ github.repository }}"
           ref: master
-          path: ./github-wiki-organisers
       - name: Checkout the Wiki Repository
         uses: actions/checkout@v7
         with:
           repository: "${{ github.repository }}.wiki"
           ref: master
-          path: ./github-wiki-organisers/wiki
+          path: ./wiki
+      # The Ruby entry points resolve the wiki as base_path '../..', i.e. they
+      # expect to run from <wiki>/github-wiki-organisers/ruby (the wiki tracks
+      # the main repository as a submodule there). The submodule's SSH URL
+      # cannot be cloned with GITHUB_TOKEN, so copy the checkout into that path
+      # instead; git ignores the contents of an uninitialised submodule path,
+      # so commit-and-push will not pick the copy up.
+      - name: Nest the Main Repository in the Wiki
+        run: rsync -a --exclude .git --exclude wiki ./ wiki/github-wiki-organisers/
       - name: Configure Git Identity
-        uses: ./github-wiki-organisers/.github/actions/configure-git-identity
-      - uses: actions/checkout@v7
-      - uses: ./github-wiki-organisers/.github/actions/setup-ruby
+        uses: ./.github/actions/configure-git-identity
+      - uses: ./.github/actions/setup-ruby
+        with:
+          job-name: export_unknown_wiki_list_for_llm
       - name: Export Unknown Wiki List for LLM
-        working-directory: ./github-wiki-organisers/wiki
+        working-directory: ./wiki
         run: |
           set -xe
           git pull origin master
-          bash export_unknown_wiki_list_for_llm.sh "${{ github.event.inputs.group_by || 'Owner' }}" "${{ github.event.inputs.language || 'English' }}"
+          cd github-wiki-organisers/ruby
+          printf '%s\n%s\n' "${{ github.event.inputs.group_by || 'Owner' }}" "${{ github.event.inputs.language || 'English' }}" | rake export_unknown_wiki_list_for_llm
       - name: Commit and Push
         id: commit
-        uses: ./github-wiki-organisers/.github/actions/commit-and-push
+        uses: ./.github/actions/commit-and-push
         with:
-          working-directory: ./github-wiki-organisers/wiki
+          working-directory: ./wiki
           commit-message-prefix: "Commit unknown_wiki_list_for_llm.txt by GitHub Actions[bot]"
 
   notify:

--- a/.github/workflows/notify-wiki-count-by-namespace.yml
+++ b/.github/workflows/notify-wiki-count-by-namespace.yml
@@ -26,21 +26,32 @@ jobs:
     outputs:
       uncategorised_wiki_count: ${{ steps.format.outputs.uncategorised_wiki_count }}
     steps:
+      # The main repository must live at the workspace root so that the local
+      # .github/actions/* resolve and ruby/setup-ruby finds .ruby-version.
+      - name: Checkout the Main Repository
+        uses: actions/checkout@v7
       - name: Checkout the Wiki Repository
         uses: actions/checkout@v7
         with:
           repository: "${{ github.repository }}.wiki"
           ref: master
           path: .wiki
-      - uses: actions/checkout@v7
-      - uses: ./github-wiki-organisers/.github/actions/setup-ruby
+      # The Ruby entry points resolve the wiki as base_path '../..', i.e. they
+      # expect to run from <wiki>/github-wiki-organisers/ruby (the wiki tracks
+      # the main repository as a submodule there). The submodule's SSH URL
+      # cannot be cloned with GITHUB_TOKEN, so copy the checkout into that path.
+      - name: Nest the Main Repository in the Wiki
+        run: rsync -a --exclude .git --exclude .wiki ./ .wiki/github-wiki-organisers/
+      - uses: ./.github/actions/setup-ruby
+        with:
+          job-name: count_uncategorised
       - name: Format Uncategorised Wiki Count by Namespace
         id: format
         working-directory: .wiki
         run: |
           set -xe
           git pull origin master
-          bash export_unknown_wiki_count_list_by_namespace.sh Category "${{ github.event.inputs.language || 'English' }}"
+          (cd github-wiki-organisers/ruby && printf 'Category\n%s\n' "${{ github.event.inputs.language || 'English' }}" | rake export_unknown_wiki_count_list_by_namespace)
           uncategorised_wiki_count=$(ruby -e "puts File.readlines('unknown_wiki_count_list_by_namespace.txt')[0]")
           echo "uncategorised_wiki_count=$uncategorised_wiki_count" >> $GITHUB_OUTPUT
           rm unknown_wiki_count_list_by_namespace.txt
@@ -68,21 +79,28 @@ jobs:
       unknown_owner_nor_necessity: ${{ steps.format.outputs.unknown_owner_nor_necessity }}
       unowned: ${{ steps.format.outputs.unowned }}
     steps:
+      # See count-uncategorised for why the main repository is checked out at
+      # the workspace root and copied into the wiki's submodule path.
+      - name: Checkout the Main Repository
+        uses: actions/checkout@v7
       - name: Checkout the Wiki Repository
         uses: actions/checkout@v7
         with:
           repository: "${{ github.repository }}.wiki"
           ref: master
           path: .wiki
-      - uses: actions/checkout@v7
-      - uses: ./github-wiki-organisers/.github/actions/setup-ruby
+      - name: Nest the Main Repository in the Wiki
+        run: rsync -a --exclude .git --exclude .wiki ./ .wiki/github-wiki-organisers/
+      - uses: ./.github/actions/setup-ruby
+        with:
+          job-name: count_unowned
       - name: Format Unknown Wiki Count by Namespace
         id: format
         working-directory: .wiki
         run: |
           set -xe
           git pull origin master
-          bash export_unknown_wiki_count_list_by_namespace.sh Owner "${{ github.event.inputs.language || 'English' }}"
+          (cd github-wiki-organisers/ruby && printf 'Owner\n%s\n' "${{ github.event.inputs.language || 'English' }}" | rake export_unknown_wiki_count_list_by_namespace)
           unknown_but_necessary=$(ruby -e "puts File.readlines('unknown_wiki_count_list_by_namespace.txt')[0]")
           unknown_owner_nor_necessity=$(ruby -e "puts File.readlines('unknown_wiki_count_list_by_namespace.txt')[1]")
           unowned=$(ruby -e "puts File.readlines('unknown_wiki_count_list_by_namespace.txt')[2]")

--- a/.github/workflows/update-wiki-list-on-home-and-sidebar.yml
+++ b/.github/workflows/update-wiki-list-on-home-and-sidebar.yml
@@ -96,5 +96,5 @@ jobs:
           header: "【github-wiki-organisers Daily Wiki List on Home and Sidebar Update Report】"
           mrkdwn-sections: |
             Workflows: <https://github.com/${{ github.repository }}/blob/master/.github/workflows/update-wiki-list-on-home-and-sidebar.yml|Update Wiki List on Home and Sidebar>
-            Commit: ${{ needs.update.outputs.commit_message }}
+            Commit: ${{ needs.update_wiki_list_on_home_and_sidebar.outputs.commit_message }}
             Source: <https://github.com/${{ github.repository }}/wiki|github-wiki-organisers Wiki>

--- a/.github/workflows/update-wiki-list-on-home-and-sidebar.yml
+++ b/.github/workflows/update-wiki-list-on-home-and-sidebar.yml
@@ -41,33 +41,44 @@ jobs:
       commit_message: ${{ steps.commit.outputs.commit_message }}
       jst_current_datetime: ${{ steps.commit.outputs.jst_current_datetime }}
     steps:
+      # The main repository must live at the workspace root so that the local
+      # .github/actions/* resolve and ruby/setup-ruby finds .ruby-version.
       - name: Checkout the Main Repository
         uses: actions/checkout@v7
         with:
           repository: "${{ github.repository }}"
           ref: master
-          path: ./github-wiki-organisers
       - name: Checkout the Wiki Repository
         uses: actions/checkout@v7
         with:
           repository: "${{ github.repository }}.wiki"
           ref: master
-          path: ./github-wiki-organisers/wiki
+          path: ./wiki
+      # The Ruby entry points resolve the wiki as base_path '../..', i.e. they
+      # expect to run from <wiki>/github-wiki-organisers/ruby (the wiki tracks
+      # the main repository as a submodule there). The submodule's SSH URL
+      # cannot be cloned with GITHUB_TOKEN, so copy the checkout into that path
+      # instead; git ignores the contents of an uninitialised submodule path,
+      # so commit-and-push will not pick the copy up.
+      - name: Nest the Main Repository in the Wiki
+        run: rsync -a --exclude .git --exclude wiki ./ wiki/github-wiki-organisers/
       - name: Configure Git Identity
-        uses: ./github-wiki-organisers/.github/actions/configure-git-identity
-      - uses: actions/checkout@v7
-      - uses: ./github-wiki-organisers/.github/actions/setup-ruby
+        uses: ./.github/actions/configure-git-identity
+      - uses: ./.github/actions/setup-ruby
+        with:
+          job-name: update_wiki_list_on_home_and_sidebar
       - name: Update github-wiki-organisers Wiki
-        working-directory: ./github-wiki-organisers/wiki
+        working-directory: ./wiki
         run: |
           set -xe
           git pull origin master
-          bash update_wiki_list_on_home_and_sidebar.sh "${{ github.event.inputs.group_by || 'Owner' }}" "${{ github.event.inputs.language || 'English' }}" "${{ github.event.inputs.home_overflow || false }}"
+          cd github-wiki-organisers/ruby
+          printf '%s\n%s\n%s\n' "${{ github.event.inputs.group_by || 'Owner' }}" "${{ github.event.inputs.language || 'English' }}" "${{ github.event.inputs.home_overflow || false }}" | rake update_wiki_list_on_home_and_sidebar
       - name: Commit and Push
         id: commit
-        uses: ./github-wiki-organisers/.github/actions/commit-and-push
+        uses: ./.github/actions/commit-and-push
         with:
-          working-directory: ./github-wiki-organisers/wiki
+          working-directory: ./wiki
           commit-message-prefix: "Update Wiki list on Home and Sidebar by GitHub Actions[bot]"
 
   notify:


### PR DESCRIPTION
## 1. Overview

- Follow-up to #111.

All three Wiki cron jobs (`Update Wiki List on Home and Sidebar`, `Export Unknown Wiki List for LLM`, `Notify Wiki Count by Namespace`) failed because the bare `actions/checkout` step wiped the workspace and broke the resolution of the local `setup-ruby` action.  
Underneath that, the Wiki's shell scripts still call `ruby ./exec/*.rb`, which was removed in d2a58b3 ("Migrate from execution files to Rakefile"), and their trailing `cd` masked the failure — so even "successful" past runs never actually updated the Wiki. This PR reworks the checkout layout and invokes the Rake tasks directly so the cron jobs do real work.

## 2. Key Changes & Differences

|Workflows |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|update-wiki-list-on-home-and-sidebar.yml |Main repository checked out under `./github-wiki-organisers`, then a bare `actions/checkout` wiped it; ran the Wiki's `update_wiki_list_on_home_and_sidebar.sh` |Main repository at the workspace root, Wiki at `./wiki`, git-less copy of the repository nested on the Wiki's `github-wiki-organisers` submodule path; pipes the inputs to `rake update_wiki_list_on_home_and_sidebar` via stdin |Local actions and `.ruby-version` resolve again, and the job performs a real Home/Sidebar update |
|update-wiki-list-on-home-and-sidebar.yml (notify job) |`needs.update.outputs.commit_message` |`needs.update_wiki_list_on_home_and_sidebar.outputs.commit_message` |The Slack report's Commit line always rendered empty because the referenced job id did not exist |
|export-unknown-wiki-list-for-llm.yml |Same broken layout; ran the Wiki's `export_unknown_wiki_list_for_llm.sh` |Same reworked layout; runs `rake export_unknown_wiki_list_for_llm` |`unknown_wiki_list_for_llm.txt` is actually exported to the Wiki root and committed |
|notify-wiki-count-by-namespace.yml |Wiki at `.wiki`, bare `actions/checkout` wiped it, and the `setup-ruby` path pointed at a non-existent `./github-wiki-organisers` prefix; ran the Wiki's `export_unknown_wiki_count_list_by_namespace.sh` |Main repository at the workspace root plus nested copy under `.wiki/github-wiki-organisers`; runs `rake export_unknown_wiki_count_list_by_namespace` |Both count jobs produce `unknown_wiki_count_list_by_namespace.txt` and the Slack counts are real |

## 3. Summary

- Checked out the main repository at the workspace root so the local `./.github/actions/*` and `.ruby-version` resolve, matching the layout of the CI workflows.
- Nested a git-less `rsync` copy of the repository on the Wiki's `github-wiki-organisers` submodule path: the Ruby entry points resolve the Wiki as `base_path: '../..'`, the submodule's SSH URL cannot be cloned with `GITHUB_TOKEN`, and git ignores the contents of an uninitialised submodule path so `commit-and-push` does not pick the copy up.
- Replaced the Wiki's stale shell scripts with direct stdin-fed Rake task invocations; the full pipeline was verified locally on Ruby 4.0.5 with the exact CI layout (Home.md updated, both export files written to the Wiki root).
- Fixed the Slack notification's commit message reference in the notify job.
- Follow-up: the Wiki repository's `*.sh` scripts are now unused and can be deleted.

## 4. References

- [.github/workflows/update-wiki-list-on-home-and-sidebar.yml](https://github.com/hayat01sh1da/github-wiki-organisers/blob/hayat01sh1da/followup/github-actions/amend-configuration-of-cron-jobs-for-wiki/.github/workflows/update-wiki-list-on-home-and-sidebar.yml)
- [.github/workflows/export-unknown-wiki-list-for-llm.yml](https://github.com/hayat01sh1da/github-wiki-organisers/blob/hayat01sh1da/followup/github-actions/amend-configuration-of-cron-jobs-for-wiki/.github/workflows/export-unknown-wiki-list-for-llm.yml)
- [.github/workflows/notify-wiki-count-by-namespace.yml](https://github.com/hayat01sh1da/github-wiki-organisers/blob/hayat01sh1da/followup/github-actions/amend-configuration-of-cron-jobs-for-wiki/.github/workflows/notify-wiki-count-by-namespace.yml)
- [Failing run that surfaced the issue](https://github.com/hayat01sh1da/github-wiki-organisers/actions/runs/29227362456/job/86744210110)
- [Checking out multiple repos — actions/checkout](https://github.com/actions/checkout#checkout-multiple-repos-side-by-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
