### PR TITLE
[GitHub Actions] Fix Path to Nested Repo

### DIFF
--- a/.github/workflows/export-unknown-wiki-list-for-llm.yml
+++ b/.github/workflows/export-unknown-wiki-list-for-llm.yml
@@ -55,7 +55,7 @@ jobs:
       # instead; git ignores the contents of an uninitialised submodule path,
       # so commit-and-push will not pick the copy up.
       - name: Nest the Main Repository in the Wiki
-        run: rsync -a --exclude .git --exclude wiki ./ wiki/spreen-wiki/
+        run: rsync -a --exclude .git --exclude /wiki ./ wiki/spreen-wiki/
       - name: Configure Git Identity
         uses: ./.github/actions/configure-git-identity
       - uses: ./.github/actions/setup-ruby

--- a/.github/workflows/notify-wiki-count-by-namespace.yml
+++ b/.github/workflows/notify-wiki-count-by-namespace.yml
@@ -41,7 +41,7 @@ jobs:
       # the main repository as a submodule there). The submodule's SSH URL
       # cannot be cloned with GITHUB_TOKEN, so copy the checkout into that path.
       - name: Nest the Main Repository in the Wiki
-        run: rsync -a --exclude .git --exclude .wiki ./ .wiki/spreen-wiki/
+        run: rsync -a --exclude .git --exclude /.wiki ./ .wiki/spreen-wiki/
       - uses: ./.github/actions/setup-ruby
         with:
           job-name: count_uncategorised
@@ -94,7 +94,7 @@ jobs:
           ref: master
           path: .wiki
       - name: Nest the Main Repository in the Wiki
-        run: rsync -a --exclude .git --exclude .wiki ./ .wiki/spreen-wiki/
+        run: rsync -a --exclude .git --exclude /.wiki ./ .wiki/spreen-wiki/
       - uses: ./.github/actions/setup-ruby
         with:
           job-name: count_unowned

--- a/.github/workflows/update-wiki-list-on-home-and-sidebar.yml
+++ b/.github/workflows/update-wiki-list-on-home-and-sidebar.yml
@@ -61,7 +61,7 @@ jobs:
       # instead; git ignores the contents of an uninitialised submodule path,
       # so commit-and-push will not pick the copy up.
       - name: Nest the Main Repository in the Wiki
-        run: rsync -a --exclude .git --exclude wiki ./ wiki/spreen-wiki/
+        run: rsync -a --exclude .git --exclude /wiki ./ wiki/spreen-wiki/
       - name: Configure Git Identity
         uses: ./.github/actions/configure-git-identity
       - uses: ./.github/actions/setup-ruby


### PR DESCRIPTION
## 1. Overview

The wiki cron jobs failed with `LoadError: cannot load such file -- .../RubyGem/lib/spreen/wiki/version` after the `spreen-wiki` rebranding ([failing run](https://github.com/hayat01sh1da/spreen-wiki/actions/runs/29264307630/job/86865426759)).  
The culprit was not Ruby but rsync: the `--exclude wiki` pattern is unanchored, so it matches **every** path whose basename is `wiki` — and since the `Spreen::Wiki` rename, that includes `RubyGem/lib/spreen/wiki/` (the entire gem body) and `RubyGem/sig/generated/spreen/wiki/`.  
The nested copy therefore contained `lib/spreen/wiki.rb` but not `lib/spreen/wiki/version.rb`, and the first `require_relative 'wiki/version'` aborted the Rake task.  

Anchoring the pattern to the transfer root (`--exclude /wiki`) keeps its real job — leaving the nested wiki checkout out of the copy — while no longer swallowing same-named directories deeper in the tree.  
The bug never fired before the rebranding simply because nothing in the old `GithubWikiOrganiser` tree was named `wiki`.  

## 2. Key Changes & Differences

|Workflows |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|`update-wiki-list-on-home-and-sidebar.yml` |`rsync -a --exclude .git --exclude wiki ./ wiki/spreen-wiki/` |`rsync -a --exclude .git --exclude /wiki ./ wiki/spreen-wiki/` |The exclude now only matches the `wiki/` checkout at the transfer root; `RubyGem/lib/spreen/wiki/` is copied intact. |
|`export-unknown-wiki-list-for-llm.yml` |`--exclude wiki` |`--exclude /wiki` |Same fix for the LLM-export cron. |
|`notify-wiki-count-by-namespace.yml` (both jobs) |`--exclude .wiki` |`--exclude /.wiki` |Same latent bug anchored for consistency — `.wiki` had no in-tree collision yet, but only by luck. |

## 3. Summary

- One-character-class bug, whole-gem impact: the unanchored rsync exclude dropped `lib/spreen/wiki/` from the nested copy, so every wiki cron aborted at the first `require`.  
- Verified locally before this fix was committed: with `--exclude /wiki`, the copied tree contains `lib/spreen/wiki/version.rb` and the sig files, and a full cron dry run (fresh wiki clone → anchored rsync → piped-stdin `rake update_wiki_list_on_home_and_sidebar` → `git add -A`) completes and stages **only** genuine wiki page diffs — the uninitialised-submodule safety mechanism still holds.  
- After merging, re-run [Update Wiki List on Home and Sidebar](https://github.com/hayat01sh1da/spreen-wiki/actions/workflows/update-wiki-list-on-home-and-sidebar.yml) to confirm green in CI.  

## 4. References

- [Failing run: Update Wiki List on Home and Sidebar](https://github.com/hayat01sh1da/spreen-wiki/actions/runs/29264307630/job/86865426759)
- [.github/workflows/update-wiki-list-on-home-and-sidebar.yml](https://github.com/hayat01sh1da/spreen-wiki/blob/hayat01sh1da/github-actions/fix-path-to-nested-repo/.github/workflows/update-wiki-list-on-home-and-sidebar.yml)
- [.github/workflows/export-unknown-wiki-list-for-llm.yml](https://github.com/hayat01sh1da/spreen-wiki/blob/hayat01sh1da/github-actions/fix-path-to-nested-repo/.github/workflows/export-unknown-wiki-list-for-llm.yml)
- [.github/workflows/notify-wiki-count-by-namespace.yml](https://github.com/hayat01sh1da/spreen-wiki/blob/hayat01sh1da/github-actions/fix-path-to-nested-repo/.github/workflows/notify-wiki-count-by-namespace.yml)
- [rsync manual — FILTER RULES (anchoring patterns with a leading `/`)](https://download.samba.org/pub/rsync/rsync.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
