### PR TITLE
Assign the first version on CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).  
 One repository hosts two packages, so releases are tagged per ecosystem (`ruby-vX.Y.Z` for the RubyGems gem, `python-vX.Y.Z` for the PyPI library).
 
-## [Unreleased]
+## 0.1.0
 
 ### 1. Added
 


### PR DESCRIPTION
## 1. Overview

On `CHANGELOG.md`, the first release version has stayed `Unreleased`.
However, `0.1.0` has already released, so `0.1.0` should be assigned to the placeholder.


## 2. Key Changes & Differences

|Code/Library/Package |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|CHANGELOG.md |`[Unreleased]` |`0.1.0` |The first release version assigned |

## 3. Summary

- `Unreleased` placeholder has been replaced with the first release version `0.1.0`

## 4. References

- [spreen-wiki](https://rubygems.org/gems/spreen-wiki)
- [spreen-wiki](https://pypi.org/project/spreen-wiki/)