### PR TITLE
[release] Prepare RubyGem v0.2.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).  
 One repository hosts two packages, so releases are tagged per ecosystem (`ruby-vX.Y.Z` for the RubyGems gem, `python-vX.Y.Z` for the PyPI library).
 
+## 0.2.0
+
+RubyGem only — the PyPI library has no shipped changes since `0.1.0` and stays on that version, so no `python-v0.2.0` tag is cut.
+
+### 1. Added
+
+- RubyGem release automation: `RubyGem/Rakefile` defines the Bundler gem tasks with the `ruby-` tag prefix, and `.github/workflows/rubygem--release.yml` builds and publishes via RubyGems Trusted Publishing on `ruby-v*` tags.
+- PyPI release automation: `.github/workflows/pypi--release.yml` builds the distributions and publishes via PyPI Trusted Publishers on `python-v*` tags, with the OIDC grant isolated in a `pypi`-environment publish job.
+- Ecosystem-scoped toolchain version files `RubyGem/.ruby-version` and `PyPI/.python-version`, alongside the repository-root ones.
+
+### 2. Changed
+
+- **Breaking (gem):** renamed the Ruby namespace from `Spreen::Wiki` to `SpreenWiki` and the lib path from `lib/spreen/wiki/` to `lib/spreen_wiki/`, matching the Python package's flat `spreen_wiki` layout. `require 'spreen-wiki'`, the gem name and the `spreen` CLI are unchanged, so CLI users are unaffected; library callers must replace `Spreen::Wiki::Home` with `SpreenWiki::Home` (likewise `Sidebar`, `UnknownWikiCountListExporter`, `UnknownWikiListExporterForLLM`, `Configuration`, `Application`).
+- Bumped the development Ruby toolchain from 4.0.5 to 4.0.6; the gem's `required_ruby_version` remains `>= 3.4`.
+- Updated the daily RubyGems dependencies (`concurrent-ruby` 1.3.7 → 1.3.8); the gem has no runtime dependencies, so this affects the development bundle only.
+- `.github/scripts/dependency_report.sh` labels ecosystems by registry name (`PyPI` / `RubyGems` / `npm`) instead of by installer command (`pip` / `gem` / `pnpm`).
+- Refined the `README.md` "Origin of the Name" section and replaced the obsolete workflow captures with current ones.
+- Rewrote `SECURITY.md` for the packaged releases, and pinned explicit `permissions` on the CodeQL workflow.
+- Numbered the `CHANGELOG.md` section headings to match the convention used across the other repositories.
+
+### 3. Removed
+
+- The `Spreen::Wiki` namespace and the `lib/spreen/wiki/` load path, superseded by `SpreenWiki` and `lib/spreen_wiki/`. `require 'spreen/wiki'` no longer resolves.
+
 ## 0.1.0
 
 ### 1. Added
@@ -19,7 +43,6 @@ One repository hosts two packages, so releases are tagged per ecosystem (`ruby-v
 
 - Renamed the repository to `spreen-wiki` and the ecosystem directories to `RubyGem/` (from `ruby/`) and `PyPI/` (from `python/`).
 - Named the packages **`spreen-wiki`** — a blend of the falcon's *stoop* and the *preen* that follows, after Hayato (隼人, "falcon man"): RubyGem `spreen-wiki` (`Spreen::Wiki`), PyPI `spreen-wiki` (`spreen_wiki`), CLI `spreen`, config file `.spreen.yml` (renamed from the working titles `github_wiki_organiser` / `github-wiki-organiser`, CLI `wiki-organise`, `.wiki-organiser.yml`).
-- Renamed the Ruby namespace from `Spreen::Wiki` to `SpreenWiki` and the lib path from `lib/spreen/wiki/` to `lib/spreen_wiki/`, matching the Python package's flat `spreen_wiki` layout; `require 'spreen-wiki'`, the gem name and the `spreen` CLI are unchanged.
 - Generalised the hardcoded assumptions: the organisation/repository/wiki URL, the owner-team URL, the template path, the scanned base path (now defaulting to the current directory), the excluded directories and the export filenames are all configuration, with the previous behaviour preserved as defaults.
 - Owner headings degrade gracefully to unlinked text when no organisation is configured instead of linking to a hardcoded personal account.
 - The wiki cron workflows pass `ORGANISATION_NAME` from `github.repository_owner` and keep driving the (unchanged) interactive Rake task interface.

--- a/RubyGem/Gemfile.lock
+++ b/RubyGem/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spreen-wiki (0.1.0)
+    spreen-wiki (0.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -161,7 +161,7 @@ CHECKSUMS
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  spreen-wiki (0.1.0)
+  spreen-wiki (0.2.0)
   steep (2.0.0) sha256=6eb0ecc09637bbb54f0a5f2cf63daea6d3208ccace64b4f1107d976333605c30
   strscan (3.1.8) sha256=aae2db611a225559f21ffbb71765c9a4e60fd262534a9ea84f4f11c7f32f679e
   terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2

--- a/RubyGem/lib/spreen_wiki/version.rb
+++ b/RubyGem/lib/spreen_wiki/version.rb
@@ -2,5 +2,5 @@
 # rbs_inline: enabled
 
 module SpreenWiki
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
## 1. Overview

Prepares the next RubyGem release as **v0.2.0**, not v0.1.1.  
The namespace rename from `Spreen::Wiki` to `SpreenWiki` landed *after* the `ruby-v0.1.0` tag was cut, so the gem published on RubyGems still ships the old namespace under `lib/spreen/wiki/`.  
Releasing that rename would remove a public namespace, which a patch bump would hide from anyone who installed 0.1.0 — so the minor is bumped instead.  

The `CHANGELOG.md` `0.1.0` section was written after the tags and described the rename as if it had shipped; that entry is moved into the new `0.2.0` section so each section matches what its tag actually published.  

The PyPI library is untouched: the diff from `python-v0.1.0` to `master` is a single unpackaged `.python-version` file, so the distribution is byte-identical to 0.1.0 and stays on that version.  
No `python-v0.2.0` tag is cut, which the per-ecosystem tagging scheme already accommodates.  

## 2. Key Changes & Differences

|Files |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|`RubyGem/lib/spreen_wiki/version.rb` |`VERSION = '0.1.0'` |`VERSION = '0.2.0'` |Minor bump, chosen over a patch because the unreleased namespace rename removes `Spreen::Wiki`. |
|`RubyGem/Gemfile.lock` |`spreen-wiki (0.1.0)` |`spreen-wiki (0.2.0)` |Regenerated by `bundle install` so the `PATH` and `CHECKSUMS` blocks track the new version. |
|`CHANGELOG.md` |Single `0.1.0` section, containing the namespace-rename entry |New `0.2.0` section above `0.1.0`, holding the rename |Each section now matches what its tag shipped; `0.2.0` adds Added/Changed/Removed entries for the release workflows, the toolchain bump, the ecosystem label rename and the removed `Spreen::Wiki` namespace. |
|`PyPI/pyproject.toml` |`version = "0.1.0"` |`version = "0.1.0"` |Deliberately unchanged — no shipped diff since `python-v0.1.0`. |

## 3. Summary

- The gem goes out as **0.2.0**; the PyPI library stays on **0.1.0**, the first point where the two ecosystems diverge.
- `require 'spreen/wiki'` and the `Spreen::Wiki` constant stop resolving in 0.2.0; `require 'spreen-wiki'`, the gem name and the `spreen` CLI are unchanged, so CLI-only users are unaffected.
- Verified before commit: `bundle exec rake test` passes (174 runs, 323 assertions, 0 failures, 0 errors), and `gem build spreen-wiki.gemspec` produces `spreen-wiki-0.2.0.gem`.
- Merging this PR publishes nothing on its own — the `ruby-v0.2.0` tag push is what triggers `RubyGem - Release`.

### Follow-up (not in this PR)

- `.github/workflows/rubygem--ci.yml` and `pypi--ci.yml` filter paths on the repository-root `.ruby-version` / `.python-version`, so the newly added `RubyGem/.ruby-version` and `PyPI/.python-version` do not trigger those workflows. Both root files still exist, so nothing is broken today, but the duplication is worth resolving.
- `.github/workflows/pypi--release.yml` reads `python-version-file: .python-version` from the repository root rather than `PyPI/`, for the same reason.

## 4. References

- [CHANGELOG.md](https://github.com/hayat01sh1da/spreen-wiki/blob/hayat01sh1da/release/prepare-rubygem-v0.2.0-release/CHANGELOG.md)
- [RubyGem/lib/spreen_wiki/version.rb](https://github.com/hayat01sh1da/spreen-wiki/blob/hayat01sh1da/release/prepare-rubygem-v0.2.0-release/RubyGem/lib/spreen_wiki/version.rb)
- [RubyGem/Gemfile.lock](https://github.com/hayat01sh1da/spreen-wiki/blob/hayat01sh1da/release/prepare-rubygem-v0.2.0-release/RubyGem/Gemfile.lock)
- [spreen-wiki on RubyGems](https://rubygems.org/gems/spreen-wiki) — currently 0.1.0 only
- [spreen-wiki on PyPI](https://pypi.org/project/spreen-wiki/) — currently 0.1.0 only
- [Semantic Versioning 2.0.0 § 4](https://semver.org/spec/v2.0.0.html) — major version zero, and the convention of bumping the minor for breaking changes while `0.x`
- [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/)