### PR TITLE
[overall] Update Environment Info

### DIFF
--- a/RubyGem/README.md
+++ b/RubyGem/README.md
@@ -50,8 +50,8 @@ All classes accept `base_path:`, `group_by:`, `language:`, `home_overflow:` plus
 ### 4-1. Environment
 
 - Ruby 4.0.6
-- Gemfile 4.0.16
-- Bundler 4.0.16
+- Gemfile 4.0.17
+- Bundler 4.0.17
 
 ```command
 $ bundle install


### PR DESCRIPTION
## 1. Overview

This branch refreshes the documented development-environment versions in `RubyGem/README.md` to match the latest local toolchain.  
No gem code, dependencies, or behaviour change — the edit is limited to the environment-info block recording the Gemfile/Bundler versions.  

The bump keeps the RubyGem docs consistent with the current WSL setup so contributors reproduce the environment accurately.  

## 2. Key Changes & Differences

|Tool |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|Gemfile |4.0.16 |4.0.17 |Patch bump recorded in `RubyGem/README.md` |
|Bundler |4.0.16 |4.0.17 |Patch bump recorded in `RubyGem/README.md` |

## 3. Summary

- Documentation-only update to 1 file (`RubyGem/README.md`); 2 insertions / 2 deletions.  
- One commit bumping Gemfile & Bundler (4.0.16 → 4.0.17).  
- No gem version bump, packaging, or release impact — safe to merge without further verification.  

## 4. References

- [RubyGem/README.md](https://github.com/hayat01sh1da/spreen-wiki/blob/hayat01sh1da/no-issue/overall/update-environment-info/RubyGem/README.md)