### PR TITLE
[PyPI] Sync the Version Constant with pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).  
 One repository hosts two packages, so releases are tagged per ecosystem (`ruby-vX.Y.Z` for the RubyGems gem, `python-vX.Y.Z` for the PyPI library).
 
+## 0.2.1 (PyPI)
+
+PyPI only — the RubyGems gem is unaffected and stays on `0.3.0`, so no `ruby-` tag is cut.
+
+### 1. Fixed
+
+- `wiki-organise --version` reported `0.1.0` on the `0.2.0` release. `__version__` in `spreen_wiki/__init__.py` is declared separately from the packaging metadata in `pyproject.toml`, and the `0.2.0` release bumped only the latter, so the published wheel carried a stale constant. Both now read `0.2.1`. The gem is not affected: its gemspec reads `SpreenWiki::VERSION`, so the version has a single source there.
+
+### 2. Added
+
+- `PyPI/test/test_version.py`, asserting `spreen_wiki.__version__` matches the `version` declared in `pyproject.toml`, so a release that bumps only one of the two fails CI instead of shipping.
+
 ## 0.3.0 (RubyGem) / 0.2.0 (PyPI)
 
 Both ecosystems ship this release: the gem goes `0.2.0` → `0.3.0` (tag `ruby-v0.3.0`) and the library `0.1.0` → `0.2.0` (tag `python-v0.2.0`). The version numbers differ because the library sat out `0.2.0`, which was RubyGem-only.

--- a/PyPI/pyproject.toml
+++ b/PyPI/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spreen-wiki"
-version = "0.2.0"
+version = "0.2.1"
 description = "Organise GitHub wiki Home and _Sidebar pages by owner or category."
 readme = "README.md"
 license = "MIT"

--- a/PyPI/src/spreen_wiki/__init__.py
+++ b/PyPI/src/spreen_wiki/__init__.py
@@ -9,7 +9,7 @@ from .sidebar import Sidebar
 from .unknown_wiki_count_list_exporter import UnknownWikiCountListExporter
 from .unknown_wiki_list_exporter_for_llm import UnknownWikiListExporterForLLM
 
-__version__ = '0.1.0'
+__version__ = '0.2.1'
 
 __all__ = [
     'Application',

--- a/PyPI/test/test_version.py
+++ b/PyPI/test/test_version.py
@@ -1,0 +1,20 @@
+import re
+import tomllib
+from pathlib import Path
+
+import spreen_wiki
+
+PYPROJECT = Path(__file__).resolve().parent.parent / 'pyproject.toml'
+
+
+def test_version_constant_matches_pyproject() -> None:
+    """`__version__` is declared separately from the packaging metadata, so a
+    release that bumps only `pyproject.toml` ships a wheel whose `--version`
+    reports the previous release. This guard fails that release in CI."""
+    with PYPROJECT.open('rb') as f:
+        declared = tomllib.load(f)['project']['version']
+    assert spreen_wiki.__version__ == declared
+
+
+def test_version_is_semver() -> None:
+    assert re.fullmatch(r'\d+\.\d+\.\d+', spreen_wiki.__version__)


### PR DESCRIPTION
## 1. Overview

Fixes a defect shipped in the PyPI `0.2.0` release: `wiki-organise --version` reports `0.1.0`.  

`spreen_wiki/__init__.py` declares `__version__` as a literal, separately from the packaging metadata in `pyproject.toml`. The `0.2.0` release bumped only `pyproject.toml`, so the published wheel installs as `0.2.0` but carries a stale constant and reports the previous version. The gem is not affected — its gemspec reads `SpreenWiki::VERSION` from `version.rb`, so the version has a single source there.  

PyPI `0.2.0` cannot be replaced (registry uploads are immutable), so the fix ships as `0.2.1`.  
A regression test now asserts the two declarations agree, so a release that bumps only one of them fails CI instead of shipping.  

## 2. Key Changes & Differences

|Files |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|`PyPI/src/spreen_wiki/__init__.py` |`__version__ = '0.1.0'` |`__version__ = '0.2.1'` |The constant the `--version` flag reads. It was never bumped for `0.2.0`, which is the defect. |
|`PyPI/pyproject.toml` |`version = "0.2.0"` |`version = "0.2.1"` |Patch release carrying the fix. |
|`PyPI/test/test_version.py` |— |New file |Parses `pyproject.toml` with `tomllib` and asserts `spreen_wiki.__version__` equals the declared `version`, plus a SemVer shape check. Verified to fail when the constant drifts, by reverting it to `0.1.0` and watching the assertion trip. |
|`CHANGELOG.md` |`## 0.3.0 (RubyGem) / 0.2.0 (PyPI)` at the top |`## 0.2.1 (PyPI)` |New `Fixed` and `Added` sections, noting the gem is unaffected and stays on `0.3.0`. |

## 3. Summary

- Only the PyPI library is released here (`python-v0.2.1`). The gem stays on `0.3.0` and needs no tag.  
- The single-source approach used by the gem was not available without a change of mechanism: `importlib.metadata` would read installed metadata, but `pyproject.toml` sets `pythonpath = ["src"]` so the suite imports from source where no metadata exists. Keeping the literal and guarding it with a test preserves the current import model.  
- `0.2.0` stays on PyPI and remains functional — the rename it shipped works correctly; only its self-reported version string is wrong.  
- Verified: 48 pytest tests pass (46 existing + 2 new), CI's blocking `flake8` gate (`--select=E9,F63,F7,F82`) passes, and `mypy .` is clean apart from a pre-existing missing `types-PyYAML` stub in the local environment, which CI installs from `requirements.txt`.  

## 4. References

- [PyPI/src/spreen_wiki/\_\_init\_\_.py](https://github.com/hayat01sh1da/spreen-wiki/blob/hayat01sh1da/pypi/sync-version-constant-with-pyproject/PyPI/src/spreen_wiki/__init__.py)
- [PyPI/pyproject.toml](https://github.com/hayat01sh1da/spreen-wiki/blob/hayat01sh1da/pypi/sync-version-constant-with-pyproject/PyPI/pyproject.toml)
- [PyPI/test/test_version.py](https://github.com/hayat01sh1da/spreen-wiki/blob/hayat01sh1da/pypi/sync-version-constant-with-pyproject/PyPI/test/test_version.py)
- [CHANGELOG.md](https://github.com/hayat01sh1da/spreen-wiki/blob/hayat01sh1da/pypi/sync-version-constant-with-pyproject/CHANGELOG.md)
- [`[PyPI] v0.2.0` release](https://github.com/hayat01sh1da/spreen-wiki/releases/tag/python-v0.2.0)
- [spreen-wiki on PyPI](https://pypi.org/project/spreen-wiki/)
- [PyPI: file name reuse is not permitted](https://docs.pypi.org/project-management/storage-limits/)
- [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/)
