### PR TITLE
[assets] Rename the spreen-wiki Icon Asset to Match the Package Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 # spreen-wiki
 
-<img src="./assets/spreen-icon.svg" align="center" width="300" alt="spreen: an origami falcon stooping across a falcon's-eye stone" />
+<img src="./assets/spreen-wiki-icon.svg" align="center" width="300" alt="spreen-wiki: an origami falcon stooping across a falcon's-eye stone" />
 
 Organises a GitHub wiki: generates `Home.md` and `_Sidebar.md` by grouping the pages by the **Owner** or **Category** declared on the first line of each page (English and Japanese labels built in, extensible via a config file), and exports reports of the pages whose owner or category is unknown.
 

--- a/assets/spreen-wiki-icon.svg
+++ b/assets/spreen-wiki-icon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="spreen: an origami falcon stooping across a falcon's-eye stone">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="spreen-wiki: an origami falcon stooping across a falcon's-eye stone">
   <defs>
     <linearGradient id="stone" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3d5a68"/>


### PR DESCRIPTION
## 1. Overview

The package icon shipped as `assets/spreen-icon.svg`, a name chosen when `spreen-wiki` was the only package in the family and "spreen" was the whole brand.  

Five packages later, every sibling names its icon after its own package (`spreen-pr-icon.svg`, `spreen-tracks-icon.svg`, `spreen-clean-icon.svg`, `spreen-readme-icon.svg`), so an unqualified `spreen-icon.svg` now reads as a house mark rather than as this package's mark.  

This renames the asset to `spreen-wiki-icon.svg` and updates the two references that named the old brand, bringing the repository in line with the rest of the family.  

## 2. Key Changes & Differences

|Files |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|`assets/spreen-icon.svg` |`spreen-icon.svg` |`assets/spreen-wiki-icon.svg` |Renamed via `git mv`, so the rename is recorded rather than surfacing as a delete plus an add. The drawing itself is untouched. |
|`README.md` |`<img src="./assets/spreen-icon.svg" … alt="spreen: an origami falcon stooping across a falcon's-eye stone" />` |`<img src="./assets/spreen-wiki-icon.svg" … alt="spreen-wiki: an origami falcon stooping across a falcon's-eye stone" />` |Both the `src` and the alt text updated. The alt text carried the same fossil, naming `spreen` where every sibling qualifies with its package name. |
|`assets/spreen-wiki-icon.svg` |`aria-label="spreen: an origami falcon…"` |`aria-label="spreen-wiki: an origami falcon…"` |The SVG's own accessible name matched the README alt text and needed the same correction. |

## 3. Summary

- Renames the icon asset to match the package name, completing the `spreen-<function>` naming across the five published packages.  
- Corrects two accessible names (`alt` and `aria-label`) that announced the package as `spreen`, a name retired when the CLI was renamed to `wiki-organise` in 0.3.0 (RubyGem) / 0.2.0 (PyPI).  
- **No release is required.** The asset appears in neither the gemspec `files` list nor `[tool.setuptools.package-data]`, so the gem and the wheel are byte-identical before and after this change.  
- No version bump and no CHANGELOG entry, for the same reason: nothing a package consumer can observe has changed.  

## 4. References

- [`assets/spreen-wiki-icon.svg`](https://github.com/hayat01sh1da/spreen-wiki/blob/hayat01sh1da/assets/rename-spreen-wiki-icon-to-match-the-package-name/assets/spreen-wiki-icon.svg)
- [`README.md`](https://github.com/hayat01sh1da/spreen-wiki/blob/hayat01sh1da/assets/rename-spreen-wiki-icon-to-match-the-package-name/README.md)
- [spreen-wiki on RubyGems](https://rubygems.org/gems/spreen-wiki)
- [spreen-wiki on PyPI](https://pypi.org/project/spreen-wiki/)
