### PR TITLE
[release] Prepare RubyGem v0.3.1 and PyPI v0.2.2 Releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).  
 One repository hosts two packages, so releases are tagged per ecosystem (`ruby-vX.Y.Z` for the RubyGems gem, `python-vX.Y.Z` for the PyPI library).
 
-## 0.2.1 (PyPI)
+## 0.3.1 (RubyGem) / 0.2.2 (PyPI) - 2026-08-06
+
+Both ecosystems ship this maintenance release: the gem goes `0.3.0` -> `0.3.1` (tag `ruby-v0.3.1`) and the library `0.2.1` -> `0.2.2` (tag `python-v0.2.2`).
+The `wiki-organise` CLI and the library behaviour are unchanged.
+
+### 1. Changed
+
+- Development toolchain moved to CPython 3.14.7 (`PyPI/.python-version`) and the pinned development dependencies were refreshed (`RubyGem/Gemfile.lock`, `PyPI/requirements.lock`). Runtime dependencies (`PyYAML >= 6.0`) are unchanged, and the published `requires-python` (`>= 3.10`) and `required_ruby_version` (`>= 3.4`) floors are untouched.
+- The per-ecosystem READMEs shipped inside the packages restate the refreshed toolchain versions.
+
+## 0.2.1 (PyPI) - 2026-07-31
 
 PyPI only — the RubyGems gem is unaffected and stays on `0.3.0`, so no `ruby-` tag is cut.
 
@@ -17,7 +27,7 @@ PyPI only — the RubyGems gem is unaffected and stays on `0.3.0`, so no `ruby-`
 
 - `PyPI/test/test_version.py`, asserting `spreen_wiki.__version__` matches the `version` declared in `pyproject.toml`, so a release that bumps only one of the two fails CI instead of shipping.
 
-## 0.3.0 (RubyGem) / 0.2.0 (PyPI)
+## 0.3.0 (RubyGem) / 0.2.0 (PyPI) - 2026-07-31
 
 Both ecosystems ship this release: the gem goes `0.2.0` → `0.3.0` (tag `ruby-v0.3.0`) and the library `0.1.0` → `0.2.0` (tag `python-v0.2.0`). The version numbers differ because the library sat out `0.2.0`, which was RubyGem-only.
 
@@ -29,7 +39,7 @@ Both ecosystems ship this release: the gem goes `0.2.0` → `0.3.0` (tag `ruby-v
 
 - The `spreen` executable, superseded by `wiki-organise`. No alias is shipped, so scripts, aliases and CI steps invoking `spreen` must be updated to `wiki-organise`.
 
-## 0.2.0
+## 0.2.0 - 2026-07-20
 
 RubyGem only — the PyPI library has no shipped changes since `0.1.0` and stays on that version, so no `python-v0.2.0` tag is cut.
 
@@ -53,7 +63,7 @@ RubyGem only — the PyPI library has no shipped changes since `0.1.0` and stays
 
 - The `Spreen::Wiki` namespace and the `lib/spreen/wiki/` load path, superseded by `SpreenWiki` and `lib/spreen_wiki/`. `require 'spreen/wiki'` no longer resolves.
 
-## 0.1.0
+## 0.1.0 - 2026-07-15
 
 ### 1. Added
 

--- a/PyPI/pyproject.toml
+++ b/PyPI/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spreen-wiki"
-version = "0.2.1"
+version = "0.2.2"
 description = "Organise GitHub wiki Home and _Sidebar pages by owner or category."
 readme = "README.md"
 license = "MIT"

--- a/PyPI/src/spreen_wiki/__init__.py
+++ b/PyPI/src/spreen_wiki/__init__.py
@@ -9,7 +9,7 @@ from .sidebar import Sidebar
 from .unknown_wiki_count_list_exporter import UnknownWikiCountListExporter
 from .unknown_wiki_list_exporter_for_llm import UnknownWikiListExporterForLLM
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 
 __all__ = [
     'Application',

--- a/RubyGem/lib/spreen_wiki/version.rb
+++ b/RubyGem/lib/spreen_wiki/version.rb
@@ -2,5 +2,5 @@
 # rbs_inline: enabled
 
 module SpreenWiki
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end


### PR DESCRIPTION
## 1. Overview

This Pull Request prepares the `ruby-v0.3.1` and `python-v0.2.2` releases of `spreen-wiki`.  
The two ecosystems stay on independent version lines — the gem sat out the PyPI-only `0.2.1`, so the numbers differ by design.  
The packaged `wiki-organise` CLI and the library behaviour are unchanged; what ships differently is the READMEs bundled with the packages and the version metadata itself.  
Per the repository conventions this PR stops at *prepare* — no tag is pushed and no GitHub Release is cut here, since a tag push publishes immediately.  

## 2. Key Changes & Differences

|Code/Library/Package |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|`RubyGem/lib/spreen_wiki/version.rb` |0.3.0 |0.3.1 |Gem version constant read by `spreen-wiki.gemspec`; the single source of truth for the `ruby-v0.3.1` build. |
|`PyPI/pyproject.toml` |0.2.1 |0.2.2 |Packaging metadata version for the sdist and wheel built by the `python-v0.2.2` tag. |
|`PyPI/src/spreen_wiki/__init__.py` |0.2.1 |0.2.2 |`__version__` constant, kept in step with `pyproject.toml`; `PyPI/test/test_version.py` asserts the two agree. |
|`CHANGELOG.md` |undated headings, latest `0.2.1 (PyPI)` |new section `0.3.1 (RubyGem) / 0.2.2 (PyPI) - 2026-08-06`, every heading dated |Adds the combined section and dates all five existing releases from their tags. |

## 3. Summary

- Bumps the version in all three sources and adds the dated CHANGELOG section; ready for `ruby-v0.3.1` and `python-v0.2.2` once merged.
- Patch-level — no source, no API surface and no dependency floor moved; `requires-python` (`>= 3.10`) and `required_ruby_version` (`>= 3.4`) are untouched.
- Follow-up after merge: `git tag ruby-v0.3.1 && git push origin ruby-v0.3.1` and `git tag python-v0.2.2 && git push origin python-v0.2.2` publishes via the Trusted Publishing workflows, then cut the GitHub Release(s).

## 4. References

- [`RubyGem/lib/spreen_wiki/version.rb`](https://github.com/hayat01sh1da/spreen-wiki/blob/hayat01sh1da/release/prepare-rubygem-v0.3.1-and-pypi-v0.2.2-releases/RubyGem/lib/spreen_wiki/version.rb)
- [`PyPI/pyproject.toml`](https://github.com/hayat01sh1da/spreen-wiki/blob/hayat01sh1da/release/prepare-rubygem-v0.3.1-and-pypi-v0.2.2-releases/PyPI/pyproject.toml)
- [`PyPI/src/spreen_wiki/__init__.py`](https://github.com/hayat01sh1da/spreen-wiki/blob/hayat01sh1da/release/prepare-rubygem-v0.3.1-and-pypi-v0.2.2-releases/PyPI/src/spreen_wiki/__init__.py)
- [`CHANGELOG.md`](https://github.com/hayat01sh1da/spreen-wiki/blob/hayat01sh1da/release/prepare-rubygem-v0.3.1-and-pypi-v0.2.2-releases/CHANGELOG.md)
- [`spreen-wiki` on RubyGems](https://rubygems.org/gems/spreen-wiki)
- [`spreen-wiki` on PyPI](https://pypi.org/project/spreen-wiki/)
- [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/)
- [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html)
