### PR TITLE
[release] Sync Gemfile.lock with the Gem Version

### DIFF
--- a/RubyGem/Gemfile.lock
+++ b/RubyGem/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spreen-wiki (0.3.0)
+    spreen-wiki (0.3.1)
 
 GEM
   remote: https://rubygems.org/
@@ -161,7 +161,7 @@ CHECKSUMS
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  spreen-wiki (0.3.0)
+  spreen-wiki (0.3.1)
   steep (2.0.0) sha256=6eb0ecc09637bbb54f0a5f2cf63daea6d3208ccace64b4f1107d976333605c30
   strscan (3.1.8) sha256=aae2db611a225559f21ffbb71765c9a4e60fd262534a9ea84f4f11c7f32f679e
   terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2


### PR DESCRIPTION
## 1. Overview

The `ruby-v0.3.1` release run failed and the gem was never published — this Pull Request unblocks it.  
`RubyGem/Gemfile` declares the gem itself via `gemspec`, so `RubyGem/Gemfile.lock` records it as a path gem pinned to an exact version.  
The version bump to 0.3.1 moved `version.rb` but left the lockfile on 0.3.0, and `ruby/setup-ruby` runs `bundle install` in frozen mode, which refuses to rewrite the lockfile: *"The gemspecs for path gems changed, but the lockfile can't be updated because frozen mode is set"*.  
The `rubygems/release-gem` step was skipped rather than failing mid-publish, so nothing partial reached RubyGems and the version number is still free.  
The lockfile is regenerated with Bundler 4.0.18 on Ruby 4.0.6 rather than hand-edited, so the `CHECKSUMS` entry moves with the `PATH` spec; a hand edit leaves the checksum stale and frozen mode rejects it for a second reason.  

## 2. Key Changes & Differences

|Code/Library/Package |Before |After |Changes & Differences |
|:-|:-|:-|:-|
|`RubyGem/Gemfile.lock` (`PATH` spec) |`spreen-wiki (0.3.0)` |`spreen-wiki (0.3.1)` |The path-gem pin Bundler resolves `gemspec` to; frozen mode compares it against `version.rb`. |
|`RubyGem/Gemfile.lock` (`CHECKSUMS`) |`spreen-wiki (0.3.0)` |`spreen-wiki (0.3.1)` |Checksum entry keyed by version. Regenerated by Bundler, not edited by hand. |

## 3. Summary

- Two lines change, both written by `bundle install`; no dependency version moves and no other pin is touched.
- Verified locally by replicating the CI step — `BUNDLE_FROZEN=true bundle install --jobs 4` now completes (`Bundle complete! 8 Gemfile dependencies, 36 gems now installed.`) where it previously aborted.
- Nothing was published under `ruby-v0.3.1`: [the failed run](https://github.com/hayat01sh1da/spreen-wiki/actions/runs/31087323013) stopped at `ruby/setup-ruby` and skipped `rubygems/release-gem`, so RubyGems still shows 0.3.0 as latest.
- Follow-up after merge: move `ruby-v0.3.1` onto the merge commit (`git tag -f ruby-v0.3.1 master && git push -f origin ruby-v0.3.1`) so the release workflow reruns against the fixed lockfile — re-running the existing run cannot work, because it checks out the tag's old commit.
- The PyPI side is unaffected and already live; only the gem is held back.

## 4. References

- [`RubyGem/Gemfile.lock`](https://github.com/hayat01sh1da/spreen-wiki/blob/hayat01sh1da/release/sync-gemfile-lock-with-the-gem-version/RubyGem/Gemfile.lock)
- [Failed `ruby-v0.3.1` release run](https://github.com/hayat01sh1da/spreen-wiki/actions/runs/31087323013)
- [`spreen-wiki` on RubyGems](https://rubygems.org/gems/spreen-wiki)
- [Bundler: frozen / deployment mode](https://bundler.io/man/bundle-install.1.html)
